### PR TITLE
[Release] 2025-06-30 프로젝트 초기설정 배포

### DIFF
--- a/CodeStructure.md
+++ b/CodeStructure.md
@@ -1,0 +1,367 @@
+# 🏗️ DoggyWalker Backend API - 프로젝트 초기 설정
+
+## 목차
+- [🏛️ 전체 아키텍처 개요](#--------------)
+    * [핵심 특징](#-----)
+- [📁 패키지 구조 설명](#------------)
+- [🎯 핵심 설계 원칙](#-----------)
+    * [1. 도메인 중심 설계 (Domain-Centric)](#1------------domain-centric-)
+    * [2. 의존성 역전 원칙 (DIP) 적용](#2------------dip----)
+    * [3. 계층별 DTO 분리](#3-----dto---)
+    * [4. 단일 책임 원칙](#4---------)
+- [🔄 계층별 역할과 책임](#-------------)
+    * [🌐 API 계층 (`api`)](#---api------api--)
+    * [🔧 Application 계층 (`application`)](#---application------application--)
+        + [Facade (파사드)](#facade------)
+        + [Service (서비스)](#service------)
+    * [🎯 Domain 계층 (`domain`)](#---domain------domain--)
+        + [Model (도메인 엔티티)](#model----------)
+        + [Repository Interface](#repository-interface)
+    * [🔌 Infrastructure 계층 (`infra`)](#---infrastructure------infra--)
+        + [Entity (영속성 엔티티)](#entity----------)
+        + [Repository Implementation](#repository-implementation)
+- [🎯 도메인 예외 통합 관리 체계](#------------------)
+    * [1. 통합 예외 처리 원칙](#1------------)
+    * [2. 예외 발생 위치별 처리](#2-------------)
+    * [3. User 도메인 예시](#3-user-------)
+    * [4. 장점](#4---)
+- [📚 개발 가이드라인](#-----------)
+    * [1. 새로운 도메인 추가 시](#1-------------)
+    * [2. API 개발 순서](#2-api------)
+    * [3. 코딩 규칙](#3------)
+    * [4. 주의사항](#4-----)
+- [🚀 시작하기](#-------)
+## 🏛️ 전체 아키텍처 개요
+
+본 프로젝트는 **Domain Driven Design(DDD)** 기반의 클린 아키텍처를 적용하여 구성되었습니다.
+
+### 핵심 특징
+
+- ✅ **도메인 중심 설계**: 비즈니스 로직을 도메인 계층에 집중
+- ✅ **계층 간 의존성 역전**: DIP(Dependency Inversion Principle) 적용
+- ✅ **엔티티와 도메인 모델 분리**: 영속성과 비즈니스 로직 분리
+- ✅ **DTO 계층별 분리**: API DTO와 Service DTO 분리
+- ✅ **통합 예외 처리**: 일관된 에러 응답 체계
+- ✅ **파사드 패턴**: 복잡한 유스케이스 관리
+
+
+## 📁 패키지 구조 설명
+
+```
+org.sopt.doggywalker.backendapi
+├── domain                           # 📦 도메인별 모듈
+│   └── user                         # 👤 사용자 도메인
+│       ├── api                      # 🌐 프레젠테이션 계층
+│       │   ├── controller/          # REST API 컨트롤러
+│       │   └── dto/                 # API 요청/응답 DTO
+│       │       ├── request/
+│       │       └── response/
+│       ├── application              # 🔧 애플리케이션 계층
+│       │   ├── dto/                 # 서비스 계층 DTO
+│       │   │   ├── request/
+│       │   │   └── response/
+│       │   ├── facade/              # 파사드 (유스케이스 조합)
+│       │   └── service/             # 비즈니스 서비스
+│       ├── domain                   # 🎯 도메인 모델 계층
+│       │   ├── model/               # 도메인 엔티티 (POJO)
+│       │   └── repository/          # 저장소 인터페이스
+│       ├── exception                # ❌ 도메인별 예외
+│       └── infra                    # 🔌 인프라스트럭처 계층
+│           └── persistence/
+│               ├── entity/          # JPA 엔티티
+│               └── repository/      # 저장소 구현체
+└── global                           # 🌍 전역 공통 모듈
+    ├── config/                      # 설정 클래스
+    ├── exception/                   # 공통 예외 처리
+    │   └── handler/
+    ├── infra/                       # 공통 인프라
+    │   └── persistence/entity/      # BaseEntity
+    └── response/                    # 공통 응답 포맷
+```
+
+
+## 🎯 핵심 설계 원칙
+
+### 1. 도메인 중심 설계 (Domain-Centric)
+
+- **비즈니스 로직**은 `domain.model` 패키지에 집중
+- **도메인 규칙**은 도메인 엔티티 생성자에서 검증
+- **영속성 기술**과 도메인 로직 완전 분리
+
+
+### 2. 의존성 역전 원칙 (DIP) 적용
+
+```java
+// ✅ 올바른 의존성 방향
+domain.repository.UserRepository (인터페이스)
+    ⬆️ 의존
+infra.persistence.UserRepositoryImpl (구현체)
+```
+
+
+### 3. 계층별 DTO 분리
+
+- **API DTO**: 클라이언트와의 통신용 (`api.dto`)
+- **application DTO**: application 계층 내부 통신용 (`application.dto`)
+- **Domain Model**: 순수 비즈니스 객체 (`domain.model`)
+
+
+### 4. 단일 책임 원칙
+
+- **Controller**: HTTP 요청/응답 처리만
+- **Facade**: 여러 서비스 조합 및 트랜잭션 관리
+- **Service**: 단일 도메인 비즈니스 로직
+- **Repository**: 데이터 접근만
+
+
+## 🔄 계층별 역할과 책임
+
+### 🌐 API 계층 (`api`)
+
+**역할**: HTTP 요청 수신 및 응답 반환
+
+```java
+@RestController
+public class UserController {
+    private final UserFacade userFacade;
+    
+    @PostMapping("/users")
+    public ApiResponse<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
+        CreateUserServiceRequest serviceRequest = CreateUserServiceRequest.from(request);
+        UserServiceResponse serviceResponse = userFacade.createUser(serviceRequest);
+        return ApiResponse.success(UserResponse.from(serviceResponse));
+    }
+}
+```
+
+
+### 🔧 Application 계층 (`application`)
+
+**역할**: 유스케이스 실행 및 서비스 조합
+
+#### Facade (파사드)
+
+```java
+@Component
+public class UserFacade {
+    private final UserService userService;
+    private final NotificationService notificationService;
+    
+    @Transactional
+    public UserServiceResponse createUser(CreateUserServiceRequest request) {
+        // 1. 사용자 생성
+        UserServiceResponse user = userService.createUser(request);
+        // 2. 알림 발송
+        notificationService.sendWelcomeMessage(user.getEmail());
+        return user;
+    }
+}
+```
+
+
+#### Service (서비스)
+
+```java
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    
+    public UserServiceResponse createUser(CreateUserServiceRequest request) {
+        // 도메인 모델 생성 (비즈니스 규칙 검증 포함)
+        User user = new User(request.getName(), new Email(request.getEmail()));
+        User savedUser = userRepository.save(user);
+        return UserServiceResponse.from(savedUser);
+    }
+}
+```
+
+
+### 🎯 Domain 계층 (`domain`)
+
+**역할**: 순수 비즈니스 로직 및 규칙
+
+#### Model (도메인 엔티티)
+
+```java
+public class User {
+    private final Long id;
+    private final String name;
+    private final Email email;
+    
+    public User(String name, Email email) {
+        validateName(name);  // 비즈니스 규칙 검증
+        this.name = name;
+        this.email = email;
+    }
+    
+    private void validateName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new UserBusinessException(UserErrorCode.INVALID_USER_NAME);
+        }
+    }
+}
+```
+
+
+#### Repository Interface
+
+```java
+public interface UserRepository {
+    User save(User user);
+    Optional<User> findById(Long id);
+    Optional<User> findByEmail(Email email);
+}
+```
+
+
+### 🔌 Infrastructure 계층 (`infra`)
+
+**역할**: 외부 시스템 연동 및 기술적 구현
+
+#### Entity (영속성 엔티티)
+
+```java
+@Entity
+@Table(name = "users")
+public class UserEntity extends BaseEntity {
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(nullable = false, unique = true)
+    private String email;
+    
+    // 도메인 모델로 변환
+    public User toDomain() {
+        return new User(this.id, this.name, new Email(this.email));
+    }
+    
+    // 도메인 모델에서 생성
+    public static UserEntity from(User user) {
+        return UserEntity.of(user.getName(), user.getEmail().getValue());
+    }
+}
+```
+
+
+#### Repository Implementation
+
+```java
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+    private final SpringDataUserRepository jpaRepository;
+    
+    @Override
+    public User save(User user) {
+        UserEntity entity = UserEntity.from(user);
+        UserEntity saved = jpaRepository.save(entity);
+        return saved.toDomain();
+    }
+}
+```
+
+## 🎯 도메인 예외 통합 관리 체계
+
+
+### 1. 통합 예외 처리 원칙
+
+- **모든 도메인 비즈니스 예외**는 해당 도메인의 `{Domain}ErrorCode`(예: `UserErrorCode`)에서 **통합 관리**
+- **예외 발생 시** `BusinessException`을 상속받은 도메인별 예외(예: `UserBusinessException`)만 사용
+- **커스텀 예외 클래스**를 도메인별로 추가 생성하지 않고, `ErrorCode`로 모든 케이스 구분
+
+
+### 2. 예외 발생 위치별 처리
+
+| 계층 | 예외 처리 방식 | 예시 |
+| :-- | :-- | :-- |
+| **Service** | `UserBusinessException` 던지기 + `UserErrorCode` 사용 | `throw new UserBusinessException(UserErrorCode.USER_NOT_FOUND)` |
+| **Domain Model** | `UserBusinessException` 던지기 + `UserErrorCode` 사용 | `throw new UserBusinessException(UserErrorCode.INVALID_USER_NAME)` |
+| **Controller** | Spring Validation 자동 처리 (`@Valid`) + `ResponseCode.BAD_REQUEST` 응답 | `@Valid @RequestBody CreateUserRequest` |
+| **Infra** | 기술적 예외는 `GlobalErrorCode` 사용 + `BusinessException`으로 래핑 | `throw new BusinessException(GlobalErrorCode.DATABASE_ERROR)` |
+
+### 3. User 도메인 예시
+
+**UserErrorCode.java**
+
+```java
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다"),
+    INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "U002", "유효하지 않은 사용자 이름입니다"),
+    EMAIL_DUPLICATION(HttpStatus.CONFLICT, "U003", "이메일이 중복되었습니다");
+    // ...
+}
+```
+
+**Service 계층에서 사용**
+
+```java
+public User getUserById(Long id) {
+    return userRepository.findById(id)
+        .orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+}
+```
+
+**Domain Model에서 사용**
+
+```java
+public User(String name, Email email) {
+    if (name == null || name.isBlank()) {
+        throw new UserBusinessException(UserErrorCode.INVALID_USER_NAME);
+    }
+    this.name = name;
+    this.email = email;
+}
+```
+
+
+### 4. 장점
+
+1. **일관성**: 모든 비즈니스 예외가 동일한 메커니즘(`BusinessException`)으로 처리
+2. **관리 용이**: 도메인별 에러 코드를 한 곳(`UserErrorCode`)에서 집중 관리
+3. **확장성**: 새로운 에러 유형 추가 시 열거형만 수정하면 됨
+4. **가독성**: 예외 발생 지점에서 `ErrorCode`만으로 오류 내용 명확히 표현
+
+
+## 📚 개발 가이드라인
+
+### 1. 새로운 도메인 추가 시
+
+1. `domain.{새도메인}` 패키지 생성
+2. 동일한 패키지 구조 (`api`, `application`, `domain`, `exception`, `infra`) 복사
+3. 도메인별 `ErrorCode` 정의 (접두어: 도메인 첫글자)
+
+### 2. API 개발 순서
+
+1. **도메인 모델** 정의 (`domain.model`)
+2. **서비스 DTO** 정의 (`application.dto`)
+3. **서비스 로직** 구현 (`application.service`)
+4. **API DTO** 정의 (`api.dto`)
+5. **컨트롤러** 구현 (`api.controller`)
+6. **테스트** 작성(optional)
+
+### 3. 코딩 규칙
+
+- **패키지명**: 소문자, 단수형 사용
+- **클래스명**: 역할 명시 (`UserService`, `UserController`)
+- **메서드명**: 동사 + 명사 조합 (`createUser`, `findByEmail`)
+- **예외**: 도메인별 `BusinessException` 상속
+
+
+### 4. 주의사항
+
+- **도메인 모델**에는 JPA 어노테이션 사용 금지
+- **Controller**에서 직접 `Service` 호출 금지 → `Facade` 경유
+- **크로스 도메인** 호출은 `Facade`에서만 허용
+- **외부 API** 호출은 `infra` 계층에서만
+
+
+## 🚀 시작하기
+
+1. **새로운 기능 개발** 시 `user` 도메인을 참고하여 동일한 구조로 개발
+2. **공통 기능** 추가 시 `global` 패키지 활용
+3. **예외 처리** 는 기존 패턴을 따라 `ErrorCode` 먼저 정의
+4. **테스트** 는 각 계층별로 독립적으로 작성
+
+이 구조를 통해 **유지보수성**, **확장성**, **테스트 용이성**을 확보하고, 팀원 간 **일관된 개발 패턴**을 유지할 수 있습니다.
+
+<div style="text-align: center">⁂</div>
+

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.sopt.doggywalker'
+group = 'org.sopt.doggywalker'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -27,11 +27,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    implementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/doggywalker/backendapi/DoggywalkerApplication.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/DoggywalkerApplication.java
@@ -1,4 +1,4 @@
-package com.sopt.doggywalker.backendapi;
+package org.sopt.doggywalker.backendapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DoggywalkerApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(DoggywalkerApplication.class, args);
-  }
+	public static void main(String[] args) {
+		SpringApplication.run(DoggywalkerApplication.class, args);
+	}
 
 }

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/controller/UserController.java
@@ -1,0 +1,32 @@
+package org.sopt.doggywalker.backendapi.domain.user.api.controller;
+
+import org.sopt.doggywalker.backendapi.domain.user.api.dto.request.CreateUserRequest;
+import org.sopt.doggywalker.backendapi.domain.user.api.dto.response.CreateUserResponse;
+import org.sopt.doggywalker.backendapi.domain.user.application.facade.UserFacade;
+import org.sopt.doggywalker.backendapi.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+	private final UserFacade userFacade;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<CreateUserResponse>> create(
+		@RequestBody @Valid CreateUserRequest createUserRequest) {
+
+		final CreateUserResponse response = CreateUserResponse.from(
+			userFacade.register(createUserRequest.toServiceRequest()));
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/dto/request/CreateUserRequest.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/dto/request/CreateUserRequest.java
@@ -1,0 +1,15 @@
+package org.sopt.doggywalker.backendapi.domain.user.api.dto.request;
+
+import org.sopt.doggywalker.backendapi.domain.user.application.dto.request.CreateUserServiceRequest;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateUserRequest(
+	@NotNull(message = "이름은 필수값입니다.") String name,
+	@NotNull(message = "로그인 아이디는 필수값입니다.") String loginId
+) {
+
+	public CreateUserServiceRequest toServiceRequest() {
+		return CreateUserServiceRequest.of(name(), loginId());
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/dto/response/CreateUserResponse.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/dto/response/CreateUserResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.doggywalker.backendapi.domain.user.api.dto.response;
+
+import org.sopt.doggywalker.backendapi.domain.user.application.dto.response.CreateUserServiceResponse;
+
+public record CreateUserResponse(
+	Long id,
+	String userName,
+	String loginId
+) {
+
+	public static CreateUserResponse from(final CreateUserServiceResponse userResponse) {
+		return new CreateUserResponse(
+			userResponse.id(),
+			userResponse.userName(),
+			userResponse.loginId()
+		);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/dto/request/CreateUserServiceRequest.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/dto/request/CreateUserServiceRequest.java
@@ -1,0 +1,11 @@
+package org.sopt.doggywalker.backendapi.domain.user.application.dto.request;
+
+public record CreateUserServiceRequest(
+	String name,
+	String loginId
+) {
+
+	public static CreateUserServiceRequest of(final String name, final String loginId) {
+		return new CreateUserServiceRequest(name, loginId);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/dto/response/CreateUserServiceResponse.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/dto/response/CreateUserServiceResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.doggywalker.backendapi.domain.user.application.dto.response;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+
+public record CreateUserServiceResponse(
+	Long id,
+	String userName,
+	String loginId
+) {
+
+	public static CreateUserServiceResponse from(final User user) {
+		return new CreateUserServiceResponse(user.getId(), user.getName(), user.getLoginId());
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/facade/UserFacade.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/facade/UserFacade.java
@@ -1,0 +1,22 @@
+package org.sopt.doggywalker.backendapi.domain.user.application.facade;
+
+import org.sopt.doggywalker.backendapi.domain.user.application.dto.request.CreateUserServiceRequest;
+import org.sopt.doggywalker.backendapi.domain.user.application.dto.response.CreateUserServiceResponse;
+import org.sopt.doggywalker.backendapi.domain.user.application.service.UserService;
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserFacade {
+
+	private final UserService userService;
+
+	public CreateUserServiceResponse register(CreateUserServiceRequest request) {
+		User user = userService.createUser(request);
+
+		return CreateUserServiceResponse.from(user);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/service/UserService.java
@@ -1,0 +1,9 @@
+package org.sopt.doggywalker.backendapi.domain.user.application.service;
+
+import org.sopt.doggywalker.backendapi.domain.user.application.dto.request.CreateUserServiceRequest;
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+
+public interface UserService {
+
+	User createUser(final CreateUserServiceRequest request);
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/service/UserServiceImpl.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/service/UserServiceImpl.java
@@ -1,0 +1,36 @@
+package org.sopt.doggywalker.backendapi.domain.user.application.service;
+
+import org.sopt.doggywalker.backendapi.domain.user.application.dto.request.CreateUserServiceRequest;
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.sopt.doggywalker.backendapi.domain.user.domain.repository.UserRepository;
+import org.sopt.doggywalker.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.doggywalker.backendapi.domain.user.exception.UserErrorCode;
+import org.sopt.doggywalker.backendapi.global.exception.BusinessException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+	private final UserRepository userRepository;
+
+	/**
+	 * @param request User 생성 request
+	 * @return user 도메인 모델
+	 */
+	@Override
+	public User createUser(final CreateUserServiceRequest request) {
+		final String loginId = request.loginId();
+		final String name = request.name();
+
+		if (userRepository.existsByLoginId(loginId)) {
+			throw new UserBusinessException(UserErrorCode.USER_DUPLICATE_LOGIN_ID);
+		}
+
+		User user = User.createUser(loginId, name);
+
+		return userRepository.save(user);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/model/User.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/model/User.java
@@ -1,0 +1,25 @@
+package org.sopt.doggywalker.backendapi.domain.user.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public class User {
+
+	private final Long id;
+	private final String loginId;
+	private final String name;
+
+	protected User(final Long id, final String loginId, final String name) {
+		this.id = id;
+		this.loginId = loginId;
+		this.name = name;
+	}
+
+	public static User createUser(final String loginId, final String name) {
+		return User.createUser(null, loginId, name);
+	}
+
+	public static User createUser(final Long id, final String loginId, final String name) {
+		return new User(id, loginId, name);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.doggywalker.backendapi.domain.user.domain.repository;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+
+public interface UserRepository {
+
+	User save(User user);
+
+	public boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/exception/UserBusinessException.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/exception/UserBusinessException.java
@@ -1,0 +1,10 @@
+package org.sopt.doggywalker.backendapi.domain.user.exception;
+
+import org.sopt.doggywalker.backendapi.global.exception.BusinessException;
+import org.sopt.doggywalker.backendapi.global.exception.ErrorCode;
+
+public class UserBusinessException extends BusinessException {
+	public UserBusinessException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,32 @@
+package org.sopt.doggywalker.backendapi.domain.user.exception;
+
+import org.sopt.doggywalker.backendapi.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum UserErrorCode implements ErrorCode {
+
+	USER_DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "U40900", "중복된 로그인 아이디입니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/mapper/UserMapper.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/mapper/UserMapper.java
@@ -1,0 +1,28 @@
+package org.sopt.doggywalker.backendapi.domain.user.infra.mapper;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+	/**
+	 * 데이터베이스 인프라와 통신하기 위한 객체로 변경
+	 * @param domain 유저 도메인 모델
+	 * @return 유저 엔티티
+	 */
+	public UserEntity toEntity(User domain) {
+
+		return UserEntity.createEntity(domain.getName(), domain.getLoginId());
+	}
+
+	/**
+	 * 데이터베이스 엔티티를 도메인 로직에서 사용하기 위한 도메인 모델로 변경
+	 * @param entity 유저 엔티티
+	 * @return 유저 도메인 모델
+	 */
+	public User toDomain(UserEntity entity) {
+
+		return User.createUser(entity.getId(), entity.getLoginId(), entity.getName());
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/SpringDataUserRepository.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/SpringDataUserRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.doggywalker.backendapi.domain.user.infra.persistence;
+
+import org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataUserRepository extends JpaRepository<UserEntity, Long> {
+
+	public boolean existsByLoginId(String loginId);
+
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserRepositoryImpl.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserRepositoryImpl.java
@@ -1,0 +1,30 @@
+package org.sopt.doggywalker.backendapi.domain.user.infra.persistence;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.sopt.doggywalker.backendapi.domain.user.domain.repository.UserRepository;
+import org.sopt.doggywalker.backendapi.domain.user.infra.mapper.UserMapper;
+import org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+	private final SpringDataUserRepository springDataUserRepository;
+	private final UserMapper userMapper;
+
+	@Override
+	public User save(final User user) {
+		UserEntity entity = userMapper.toEntity(user);
+		UserEntity saved = springDataUserRepository.save(entity);
+
+		return userMapper.toDomain(saved);
+	}
+
+	@Override
+	public boolean existsByLoginId(final String loginId) {
+		return springDataUserRepository.existsByLoginId(loginId);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -1,0 +1,40 @@
+package org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.sopt.doggywalker.backendapi.global.infra.persistence.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+public class UserEntity extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	private String loginId;
+
+	public static UserEntity createEntity(String name, String loginId) {
+		return UserEntity.builder()
+			.name(name)
+			.loginId(loginId)
+			.build();
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/config/JpaAuditingConfig.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.doggywalker.backendapi.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/exception/BusinessException.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package org.sopt.doggywalker.backendapi.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}
+

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/exception/ErrorCode.java
@@ -1,0 +1,12 @@
+package org.sopt.doggywalker.backendapi.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+	String getCode();
+
+	String getMessage();
+
+	HttpStatus getStatus();
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/exception/GlobalErrorCode.java
@@ -1,0 +1,31 @@
+package org.sopt.doggywalker.backendapi.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum GlobalErrorCode implements ErrorCode {
+
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G50001", "서버 내부 오류가 발생했습니다");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,132 @@
+package org.sopt.doggywalker.backendapi.global.exception.handler;
+
+import java.util.stream.Collectors;
+
+import org.sopt.doggywalker.backendapi.global.exception.BusinessException;
+import org.sopt.doggywalker.backendapi.global.exception.GlobalErrorCode;
+import org.sopt.doggywalker.backendapi.global.response.ApiResponse;
+import org.sopt.doggywalker.backendapi.global.response.ResponseCode;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(BusinessException.class)
+	public ApiResponse<Void> handleBusinessException(BusinessException ex) {
+		var ec = ex.getErrorCode();
+		log.warn("BusinessException: code={}, message={}", ec.getCode(), ex.getMessage());
+
+		return ApiResponse.error(ec.getCode(), ec.getMessage());
+	}
+
+	/**
+	 * DTO 유효성 검증 실패 처리 (@Valid, @Validated)
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ApiResponse<Void> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+		String messages = ex.getBindingResult().getFieldErrors().stream()
+			.map(FieldError::getDefaultMessage)
+			.collect(Collectors.joining("; "));
+
+		log.warn("Validation failed: {}", messages);
+
+		return ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), messages);
+	}
+
+	/**
+	 * 요청 본문(JSON 파싱 오류 처리)
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ApiResponse<Void> handleNotReadable(HttpMessageNotReadableException ex) {
+		log.warn("JSON parse error: {}", ex.getMessage());
+
+		return ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), "잘못된 요청 본문입니다");
+	}
+
+	/**
+	 * MissingServletRequestParameterException 등 바인딩 오류 처리
+	 */
+	@ExceptionHandler(BindException.class)
+	public ApiResponse<Void> handleBindException(BindException ex) {
+		String messages = ex.getBindingResult().getFieldErrors().stream()
+			.map(e -> e.getField() + ": " + e.getDefaultMessage())
+			.collect(Collectors.joining("; "));
+		log.warn("Bind error: {}", messages);
+
+		return ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), messages);
+	}
+
+	/**
+	 * 제약조건 위반 처리(@Validated on path, request param 등)
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ApiResponse<Void> handleConstraintViolation(ConstraintViolationException ex) {
+		String messages = ex.getConstraintViolations().stream()
+			.map(v -> v.getMessage())
+			.collect(Collectors.joining("; "));
+		log.warn("Constraint violation: {}", messages);
+
+		return ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), messages);
+	}
+
+	/**
+	 * 지원하지 않는 HTTP 메서드 처리
+	 */
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ApiResponse<Void> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+		String msg = String.format("지원하지 않는 메서드입니다. 허용된 메서드: %s",
+			String.join(", ", ex.getSupportedHttpMethods().stream()
+				.map(HttpMethod::name).toList()));
+		log.warn("Method not supported: {}", ex.getMethod());
+
+		return ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), msg);
+	}
+
+	/**
+	 * 지원하지 않는 미디어 타입 처리
+	 */
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	public ApiResponse<Void> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
+		String msg = String.format("지원하지 않는 미디어 타입입니다. 허용된 타입: %s",
+			String.join(", ", ex.getSupportedMediaTypes().stream()
+				.map(Object::toString).toList()));
+		log.warn("Media type not supported: {}", ex.getContentType());
+
+		return ApiResponse.error(ResponseCode.BAD_REQUEST.getCode(), msg);
+	}
+
+	/**
+	 * 핸들러 미발견 처리 (404)
+	 */
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ApiResponse<Void> handleNoHandlerFound(NoHandlerFoundException ex) {
+		log.warn("No handler found: {}", ex.getRequestURL());
+
+		return ApiResponse.error(ResponseCode.NOT_FOUND.getCode(), "요청 URL을 찾을 수 없습니다");
+	}
+
+	/**
+	 * 그 외 모든 예외 처리
+	 */
+	@ExceptionHandler(Exception.class)
+	public ApiResponse<Void> handleGenericException(Exception ex, WebRequest req) {
+		log.error("Unexpected error", ex);
+
+		return ApiResponse.error(GlobalErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+			GlobalErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/infra/persistence/entity/BaseEntity.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/infra/persistence/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package org.sopt.doggywalker.backendapi.global.infra.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/response/ApiResponse.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/response/ApiResponse.java
@@ -1,0 +1,72 @@
+package org.sopt.doggywalker.backendapi.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+	/**
+	 * 사용자 및 클라이언트가 참조할 코드
+	 */
+	private String code;
+
+	/**
+	 * 클라이언트에게 노출할 메시지
+	 */
+	private String message;
+
+	/**
+	 * 실제 응답 페이로드
+	 */
+	private T data;
+
+	/**
+	 * 성공 응답 생성
+	 *
+	 * @param data 반환할 데이터
+	 * @param <T>  데이터 타입
+	 * @return ApiResponse
+	 */
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(
+			ResponseCode.SUCCESS.getCode(),
+			ResponseCode.SUCCESS.getMessage(),
+			data
+		);
+	}
+
+	/**
+	 * 오류 응답 생성
+	 *
+	 * @param errorCode 실패 코드 enum
+	 * @param <T>       데이터 타입 (null)
+	 * @return ApiResponse
+	 */
+	public static <T> ApiResponse<T> error(ResponseCode errorCode) {
+		return new ApiResponse<>(
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			null
+		);
+	}
+
+	/**
+	 * BusinessException -> ErrorCode -> ApiResponse 로 매핑될 때 사용
+	 *
+	 * @param code    커스텀 에러코드
+	 * @param message 커스텀 메시지
+	 * @param <T>     데이터 타입 (null)
+	 * @return ApiResponse
+	 */
+	public static <T> ApiResponse<T> error(String code, String message) {
+		return new ApiResponse<>(code, message, null);
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/response/ResponseCode.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/response/ResponseCode.java
@@ -1,0 +1,31 @@
+package org.sopt.doggywalker.backendapi.global.response;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+/**
+ * 전역 응답 코드 HTTP·프레임워크 예외 대응
+ */
+@Getter
+public enum ResponseCode {
+	SUCCESS(HttpStatus.OK, "S000", "요청 처리 성공"),
+	CREATED(HttpStatus.CREATED, "S001", "리소스 생성 완료"),
+
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "E400", "잘못된 요청"),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401", "인증 필요"),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "E403", "권한 없음"),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "리소스를 찾을 수 없음"),
+	CONFLICT(HttpStatus.CONFLICT, "E409", "데이터 충돌"),
+	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500", "서버 내부 오류");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	ResponseCode(HttpStatus status, String code, String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,17 @@
 spring:
   application:
     name: doggywalker
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: false

--- a/src/test/java/org/sopt/doggywalker/backendapi/DoggywalkerApplicationTests.java
+++ b/src/test/java/org/sopt/doggywalker/backendapi/DoggywalkerApplicationTests.java
@@ -1,4 +1,4 @@
-package com.sopt.doggywalker.backendapi;
+package org.sopt.doggywalker.backendapi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DoggywalkerApplicationTests {
 
-  @Test
-  void contextLoads() {
-  }
+	@Test
+	void contextLoads() {
+	}
 
 }


### PR DESCRIPTION
## 📌 [Release] 2025-06-30 프로젝트 초기설정 배포

---

## ✨ 요약 설명
- 프로젝트 초기 설정을 마무리 지었습니다.

---

## 🧾 변경 사항
- 네이버 hackday 코드스타일을 사용하여 코드를 포맷팅하였습니다.
- 간단한 사용자 회원가입 api를 구성하였습니다!
- 아래 내용들을 반영했습니다.
✅ 도메인 중심 설계: 비즈니스 로직을 도메인 계층에 집중
✅ 계층 간 의존성 역전: DIP(Dependency Inversion Principle) 적용
✅ 엔티티와 도메인 모델 분리: 영속성과 비즈니스 로직 분리
✅ DTO 계층별 분리: API DTO와 Service DTO 분리
✅ 통합 예외 처리: 일관된 에러 응답 체계
✅ 파사드 패턴: 복잡한 유스케이스 관리
✅ 매퍼: 도메인 모델 - 엔티티 간의 매핑로직 분리

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 기타 (직접 작성: 프로젝트  초기 설정)

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="643" alt="image" src="https://github.com/user-attachments/assets/8673f18f-7202-4eb6-94df-706fe9e0867e" />


---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
.

---

## 🔗 관련 이슈
.