### PR TITLE
[feat] queryDSL 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,20 +23,47 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    queryDslVersion = "6.10.1"
+}
+
+
 dependencies {
+    // spring-boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // dev
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-
     implementation 'com.h2database:h2'
+
+    // query-dsl
+    implementation "io.github.openfeign.querydsl:querydsl-core:${queryDslVersion}"
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile;
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+tasks.named("clean") {
+    doLast {
+        delete file(querydslDir)
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/controller/UserController.java
@@ -2,7 +2,7 @@ package org.sopt.doggywalker.backendapi.domain.user.api.controller;
 
 import org.sopt.doggywalker.backendapi.domain.user.api.dto.request.CreateUserRequest;
 import org.sopt.doggywalker.backendapi.domain.user.api.dto.response.CreateUserResponse;
-import org.sopt.doggywalker.backendapi.domain.user.application.facade.UserFacade;
+import org.sopt.doggywalker.backendapi.domain.user.application.facade.command.UserRegisterFacade;
 import org.sopt.doggywalker.backendapi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,14 +18,14 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/users")
 public class UserController {
 
-	private final UserFacade userFacade;
+	private final UserRegisterFacade userRegisterFacade;
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateUserResponse>> create(
 		@RequestBody @Valid CreateUserRequest createUserRequest) {
 
 		final CreateUserResponse response = CreateUserResponse.from(
-			userFacade.register(createUserRequest.toServiceRequest()));
+			userRegisterFacade.execute(createUserRequest.toServiceRequest()));
 
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/facade/command/UserRegisterFacade.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/facade/command/UserRegisterFacade.java
@@ -1,4 +1,4 @@
-package org.sopt.doggywalker.backendapi.domain.user.application.facade;
+package org.sopt.doggywalker.backendapi.domain.user.application.facade.command;
 
 import org.sopt.doggywalker.backendapi.domain.user.application.dto.request.CreateUserServiceRequest;
 import org.sopt.doggywalker.backendapi.domain.user.application.dto.response.CreateUserServiceResponse;
@@ -10,11 +10,11 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class UserFacade {
+public class UserRegisterFacade {
 
 	private final UserService userService;
 
-	public CreateUserServiceResponse register(CreateUserServiceRequest request) {
+	public CreateUserServiceResponse execute(CreateUserServiceRequest request) {
 		User user = userService.createUser(request);
 
 		return CreateUserServiceResponse.from(user);

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/service/UserServiceImpl.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/application/service/UserServiceImpl.java
@@ -5,7 +5,6 @@ import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
 import org.sopt.doggywalker.backendapi.domain.user.domain.repository.UserRepository;
 import org.sopt.doggywalker.backendapi.domain.user.exception.UserBusinessException;
 import org.sopt.doggywalker.backendapi.domain.user.exception.UserErrorCode;
-import org.sopt.doggywalker.backendapi.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/repository/UserQueryRepository.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/repository/UserQueryRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.doggywalker.backendapi.domain.user.domain.repository;
+
+import java.util.List;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+
+public interface UserQueryRepository {
+
+	List<User> getUsers();
+
+	List<User> getUsersByNameLike(String name);
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/domain/repository/UserRepository.java
@@ -7,4 +7,6 @@ public interface UserRepository {
 	User save(User user);
 
 	public boolean existsByLoginId(String loginId);
+
+	void deleteAllInBatch();
 }

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserQueryRepositoryImpl.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserQueryRepositoryImpl.java
@@ -1,0 +1,51 @@
+package org.sopt.doggywalker.backendapi.domain.user.infra.persistence;
+
+import java.util.List;
+
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.sopt.doggywalker.backendapi.domain.user.domain.repository.UserQueryRepository;
+import org.sopt.doggywalker.backendapi.domain.user.infra.mapper.UserMapper;
+import org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity.QUserEntity;
+import org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	private final UserMapper userMapper;
+
+	@Override
+	public List<User> getUsers() {
+		QUserEntity userEntity = QUserEntity.userEntity;
+
+		List<UserEntity> userEntities = jpaQueryFactory
+			.selectFrom(userEntity)
+			.orderBy(userEntity.id.desc())
+			.fetch();
+
+		return userEntities.stream()
+			.map(userMapper::toDomain)
+			.toList();
+	}
+
+	@Override
+	public List<User> getUsersByNameLike(String name) {
+		QUserEntity userEntity = QUserEntity.userEntity;
+
+		List<UserEntity> userEntities = jpaQueryFactory
+			.selectFrom(userEntity)
+			.where(userEntity.name.like("%" + name + "%"))
+			.orderBy(userEntity.id.desc())
+			.fetch();
+
+		return userEntities.stream()
+			.map(userMapper::toDomain)
+			.toList();
+	}
+}

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserRepositoryImpl.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserRepositoryImpl.java
@@ -27,4 +27,9 @@ public class UserRepositoryImpl implements UserRepository {
 	public boolean existsByLoginId(final String loginId) {
 		return springDataUserRepository.existsByLoginId(loginId);
 	}
+
+	@Override
+	public void deleteAllInBatch() {
+		springDataUserRepository.deleteAllInBatch();
+	}
 }

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -1,6 +1,5 @@
 package org.sopt.doggywalker.backendapi.domain.user.infra.persistence.entity;
 
-import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
 import org.sopt.doggywalker.backendapi.global.infra.persistence.entity.BaseEntity;
 
 import jakarta.persistence.Entity;
@@ -13,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Entity
 @Table(name = "users")

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/config/QuerydslConfig.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package org.sopt.doggywalker.backendapi.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/test/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserQueryRepositoryImplTest.java
+++ b/src/test/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserQueryRepositoryImplTest.java
@@ -51,7 +51,7 @@ class UserQueryRepositoryImplTest {
 		// then
 		assertThat(users).hasSize(20);
 		assertThat(users).extracting("loginId")
-			.containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(1, 20).mapToObj(i ->"loginId" + i).toList());
+			.containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(1, 20).mapToObj(i -> "loginId" + i).toList());
 	}
 
 	@Test
@@ -66,6 +66,6 @@ class UserQueryRepositoryImplTest {
 		// then
 		assertThat(users).hasSize(10);
 		assertThat(users).extracting("name")
-			.containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(11, 20).mapToObj(i ->"another" + i).toList());
+			.containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(11, 20).mapToObj(i -> "another" + i).toList());
 	}
 }

--- a/src/test/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserQueryRepositoryImplTest.java
+++ b/src/test/java/org/sopt/doggywalker/backendapi/domain/user/infra/persistence/UserQueryRepositoryImplTest.java
@@ -1,0 +1,71 @@
+package org.sopt.doggywalker.backendapi.domain.user.infra.persistence;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.doggywalker.backendapi.domain.user.domain.model.User;
+import org.sopt.doggywalker.backendapi.domain.user.domain.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayName("UserQueryRepositoryImpl 통합 테스트")
+class UserQueryRepositoryImplTest {
+
+	@Autowired
+	private UserQueryRepositoryImpl userQueryRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		IntStream.rangeClosed(1, 10).forEach(i -> {
+			userRepository.save(User.createUser("loginId" + i, "name" + i));
+		});
+
+		IntStream.rangeClosed(11, 20).forEach(i -> {
+			userRepository.save(User.createUser("loginId" + i, "another" + i));
+		});
+	}
+
+	@AfterEach
+	void tearDown() {
+		userRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("UserQueryRepositoryImpl: queryDsl을 통해 전체 유저가 조회된다.")
+	void 전체_유저를_조회한다() {
+		// when
+		List<User> users = userQueryRepository.getUsers();
+
+		// then
+		assertThat(users).hasSize(20);
+		assertThat(users).extracting("loginId")
+			.containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(1, 20).mapToObj(i ->"loginId" + i).toList());
+	}
+
+	@Test
+	@DisplayName("UserQueryRepositoryImpl: queryDsl을 통해 이름 like 검색을 통과한 유저가 존재한다.")
+	void getPosts_withPagination_success() {
+		// given
+		String searchNameKeyword = "another";
+
+		// when
+		List<User> users = userQueryRepository.getUsersByNameLike(searchNameKeyword);
+
+		// then
+		assertThat(users).hasSize(10);
+		assertThat(users).extracting("name")
+			.containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(11, 20).mapToObj(i ->"another" + i).toList());
+	}
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] queryDSL 도입

---

## ✨ 요약 설명
queryDSL을 도입하고 queryDSL을 통해 간단한 유저 조회 기능을 만들고 테스트했습니다.

---

## 🧾 변경 사항
- `userQueryRepository` 인터페이스 추가 및 queryDSL 사용한 구현체 추가
- queryDSL config 추가
- 유저 queryDSLReposiotry 테스트 추가

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함
<img width="583" alt="image" src="https://github.com/user-attachments/assets/5c63a02c-f421-458d-b994-a44ef8bd7c81" />


---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 이번 풀리퀘스트는 단순히 queryDSL 을 도입하기 위한 목적이라, api를 따로 추가하지는 않았습니다.
- 테스트의 경우에도 아직 test용 profile 분리를 하지 않았으나, 따로 분리해야 할것 같습니다.
- 테스트는 h2 환경에서 이뤄졌습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #7 