### PR TITLE
✨[feat] Swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -37,6 +37,8 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'com.h2database:h2'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/domain/user/api/controller/UserController.java
@@ -3,13 +3,19 @@ package org.sopt.doggywalker.backendapi.domain.user.api.controller;
 import org.sopt.doggywalker.backendapi.domain.user.api.dto.request.CreateUserRequest;
 import org.sopt.doggywalker.backendapi.domain.user.api.dto.response.CreateUserResponse;
 import org.sopt.doggywalker.backendapi.domain.user.application.facade.UserFacade;
+import org.sopt.doggywalker.backendapi.global.exception.ErrorCode;
 import org.sopt.doggywalker.backendapi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +26,12 @@ public class UserController {
 
 	private final UserFacade userFacade;
 
+	@Operation(summary = "유저 생성", description = "회원가입 또는 유저 등록 API입니다.", tags = {"User"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CreateUserResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+	})
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateUserResponse>> create(
 		@RequestBody @Valid CreateUserRequest createUserRequest) {

--- a/src/main/java/org/sopt/doggywalker/backendapi/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/doggywalker/backendapi/global/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package org.sopt.doggywalker.backendapi.global.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public GroupedOpenApi publicApi() { // GroupedOpenApi 빈을 통해 API를 그룹화
+		return GroupedOpenApi.builder()
+			.group("springdoc-public")
+			.pathsToMatch("/**") // 모든 경로를 문서화
+			.build();
+	}
+
+	@Bean
+	public OpenAPI customOpenAPI() { // OpenAPI 빈을 사용하여 API 문서의 정보(제목, 버전, 설명)를 커스터마이징
+		return new OpenAPI()
+			.info(new Info()
+				.title("doggy-walker API")
+				.version("v1")
+				.description("doggy-walker API 명세서"));
+	}
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] Swagger 세팅

---

## ✨ 요약 설명
Swagger 사용을 위한 세팅을 진행하였습니다.

---

## 🧾 변경 사항
- springdoc-webmvc-ui에 관한 의존성을 추가하였고, 이를 호환하기 위해 **Spring Boot 버전을 3.2.5로 다운 그레이드** 진행하였습니다
- SwaggerConfig 파일을 추가하여, OpenAPI 빈을 사용하여 API 문서의 정보(제목, 버전, 설명)를 커스터마이징하도록 설정했습니다.
- UserController에서 Swagger사용을 위한 예시를 추가하였습니다.

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
-  springdoc-webmvc-ui에 관한 의존성을 호환하기 위해 **Spring Boot 버전을 3.2.5로 다운 그레이드** 진행한 경우에 대해 문제 사항이 없는지 확인주시면 좋겠습니다.
- SwaggerConfig에서 더 원활한 커스터마이징을 위해 추가할 부분이 있다면 조언 주시면 감사하겠습니다.
- Controller에서도 적극적으로 추가할 부분이 있다면 알려주세요

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #8