### PR TITLE
[fix] 배포된 swagger의 cors error(https) 설정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SwaggerConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
@@ -21,6 +22,7 @@ public class SwaggerConfig {
 	@Bean
 	public OpenAPI customOpenAPI() { // OpenAPI 빈을 사용하여 API 문서의 정보(제목, 버전, 설명)를 커스터마이징
 		return new OpenAPI()
+			.addServersItem(new Server().url("/"))
 			.info(new Info()
 				.title("paw-key API")
 				.version("v1")


### PR DESCRIPTION
## 📌 PR 제목
[bug] 배포된 swagger의 cors error(https) 설정

---

## ✨ 요약 설명
배포된 swagger에서의 cors error가 해결되도록 설정하였음.

---

## 🧾 변경 사항
SwaggerConfig에 코드 추가

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Swagger 문서에 서버 엔트리(URL: "/")가 추가되어 API 문서의 서버 정보가 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->