### PR TITLE
[feat] Swagger 설정에 octet-stream 미디어 타입 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/config/SwaggerConfig.java
@@ -1,8 +1,12 @@
 package org.sopt.pawkey.backendapi.global.config;
 
+import java.util.ArrayList;
+
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -27,5 +31,11 @@ public class SwaggerConfig {
 				.title("paw-key API")
 				.version("v1")
 				.description("paw-key API 명세서"));
+	}
+
+	public SwaggerConfig(MappingJackson2HttpMessageConverter converter) {
+		var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+		supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+		converter.setSupportedMediaTypes(supportedMediaTypes);
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목


---

## ✨ 요약 설명
Swagger UI에서 octet-stream 타입의 응답을 처리할 수 있도록
MappingJackson2HttpMessageConverter에 해당 미디어 타입을 추가합니다. 이를 통해 파일 업로드 API의 문서화 및 테스트를 용이하게 합니다.

---

## 🧾 변경 사항
- swagger config 수정


---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
<img width="1437" height="579" alt="image" src="https://github.com/user-attachments/assets/e2c8024b-1d91-47eb-b96c-131234e208ab" />
- [x] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호