### PR TITLE
[feat] 카카오 소셜 로그인인증 서버 테스트용 플로우 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/api/controller/AuthController.java
@@ -3,14 +3,18 @@ package org.sopt.pawkey.backendapi.global.auth.api.controller;
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
 import org.sopt.pawkey.backendapi.domain.user.application.facade.UserLoginFacade;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.sopt.pawkey.backendapi.global.auth.api.dto.request.LoginRequestDTO;
 import org.sopt.pawkey.backendapi.global.auth.api.dto.request.RefreshTokenRequestDTO;
 import org.sopt.pawkey.backendapi.global.auth.api.dto.response.TokenResponseDTO;
 import org.sopt.pawkey.backendapi.global.auth.application.service.TokenService;
+import org.sopt.pawkey.backendapi.global.auth.application.verifier.KakaoAuthService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +31,7 @@ public class AuthController {
 
 	private final UserLoginFacade userLoginFacade;
 	private final TokenService tokenService;
+	private final KakaoAuthService kakaoAuthService;
 
 	// 1. 소셜 로그인 API
 	@Operation(summary = "Google 소셜 로그인", description = "ID Token을 받아 사용자 인증 및 Access/Refresh Token을 최초 발급합니다.", tags = {"Auth"})
@@ -74,4 +79,12 @@ public class AuthController {
 		// 카카오는 idToken 대신 Access Token을 받으므로 request.idToken() -> accessToken 개념임
 		return userLoginFacade.kakaoLogin(request.idToken(), request.deviceId());
 	}
+	@GetMapping("/kakao/callback") //서버 테스트용 임시 컨트롤러
+	public ResponseEntity<?> kakaoCallback(@RequestParam String code) {
+		String accessToken = kakaoAuthService.exchangeCodeForAccessToken(code);
+		TokenResponseDTO tokens = userLoginFacade.kakaoLogin(accessToken, "KAKAO");
+		return ResponseEntity.ok(tokens);
+
+	}
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/KakaoAuthService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/global/auth/application/verifier/KakaoAuthService.java
@@ -1,0 +1,63 @@
+package org.sopt.pawkey.backendapi.global.auth.application.verifier;
+
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.pawkey.backendapi.global.auth.exception.AuthBusinessException;
+import org.sopt.pawkey.backendapi.global.auth.exception.AuthErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	@Value("${social.kakao.token-uri}")
+	private String kakaoTokenUri;
+
+	@Value("${social.kakao.client-id}")
+	private String clientId;
+
+	@Value("${social.kakao.redirect-uri}")
+	private String redirectUri;
+
+	public String exchangeCodeForAccessToken(String code) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", clientId);
+		params.add("redirect_uri", redirectUri);
+		params.add("code", code);
+
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+		ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+			kakaoTokenUri,
+			HttpMethod.POST,
+			request,
+			new ParameterizedTypeReference<Map<String, Object>>() {
+			}
+		);
+
+		Map<String, Object> body = response.getBody();
+		if (body == null || !body.containsKey("access_token")) {
+			throw new AuthBusinessException(AuthErrorCode.SOCIAL_LOGIN_FAIL);
+		}
+
+		String accessToken = (String)body.get("access_token");
+		return accessToken;
+
+	}
+}


### PR DESCRIPTION
## 📌 PR 제목
ex) [feat] 회원가입 API 구현  
ex) [bug] JWT 검증 오류 수정  
ex) [refactor] 응답 포맷 통일

---

## ✨ 요약 설명
카카오 OAuth2 로그인 기능을 서버 단독 환경에서 테스트할 수 있도록
인가 코드(code) → Access Token 교환 및 JWT 발급까지의 임시 플로우를 구현했습니다.
프론트엔드 연동 전 단계에서 백엔드 단독으로 카카오 로그인 연동 로직을 검증하기 위한 용도입니다.

---

## 🧾 변경 사항
- /api/v1/auth/kakao/callback 엔드포인트 추가 (테스트용 리다이렉트 수신)
- KakaoAuthService 추가 — 인가 코드(code)를 Access Token으로 교환

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #173 
- Fix #이슈번호