### PR TITLE
[bug] users.gender 컬럼 길이 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/UserEntity.java
@@ -48,7 +48,7 @@ public class UserEntity extends BaseEntity {
 	@Column(name = "name")
 	private String name;
 
-	@Column(name = "gender", length = 1)
+	@Column(name = "gender", length = 10)
 	private String gender; // 'M' or 'F'
 
 	@Column(name = "birth")


### PR DESCRIPTION
## 📌 PR 제목
ex) [bug] users.gender 컬럼 길이 수정
---

## ✨ 요약 설명
Hibernate ddl-auto=update 실행 시 users.gender 컬럼 타입 축소로 인해 발생하던 스키마 변경 오류를 해결했습니다.
기존 데이터(MALE, FEMALE)를 유지할 수 있도록 컬럼 길이를 확장하여 애플리케이션이 정상 기동되도록 수정했습니다.

---

## 🧾 변경 사항
- users.gender 컬럼 길이를 VARCHAR(1) → VARCHAR(10)으로 복구
- User 엔티티의 gender 컬럼 길이 수정
- JPA 스키마 자동 업데이트 시 발생하던 DDL 에러 제거

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트


---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #217 
- Fix #이슈번호