### PR TITLE
[refactor] JwtAuthenticationFilter에서 인증 예외를 공통 에러 포맷으로 처리

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/auth/application/service/token/TokenService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/auth/application/service/token/TokenService.java
@@ -7,6 +7,8 @@ import java.util.Set;
 
 import javax.crypto.SecretKey;
 
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
 import org.sopt.pawkey.backendapi.domain.auth.api.dto.response.TokenResponseDTO;
 import org.sopt.pawkey.backendapi.domain.auth.exception.AuthBusinessException;
 import org.sopt.pawkey.backendapi.domain.auth.exception.AuthErrorCode;
@@ -14,10 +16,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -144,7 +142,11 @@ public class TokenService {
 				.verifyWith(signingKey)
 				.build()
 				.parseSignedClaims(token);
-		} catch (Exception e) {
+		} catch (ExpiredJwtException e) {
+			throw new AuthBusinessException(AuthErrorCode.TOKEN_EXPIRED);
+		} catch (SignatureException e) {
+			throw new AuthBusinessException(AuthErrorCode.TOKEN_SIGNATURE_INVALID);
+		} catch (JwtException e) {
 			throw new AuthBusinessException(AuthErrorCode.ACCESS_TOKEN_INVALID);
 		}
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,13 +1,18 @@
 package org.sopt.pawkey.backendapi.domain.auth.filter;
 
 import java.io.IOException;
+import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.sopt.pawkey.backendapi.domain.auth.application.service.token.TokenService;
 import org.sopt.pawkey.backendapi.domain.auth.constants.AuthConstant;
+import org.sopt.pawkey.backendapi.domain.auth.exception.AuthBusinessException;
+import org.sopt.pawkey.backendapi.global.exception.ErrorCode;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -22,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final TokenService tokenService;
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Override
 	protected void doFilterInternal(
@@ -33,17 +39,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		String token = resolveToken(request);
 
 		if (token != null) {
-			// 1. 토큰 유효성 검증 & userId 추출
-			Long userId = tokenService.extractUserId(token);
 
-			// 2. 인증 객체 생성 후 SecurityContext에 저장
-			UsernamePasswordAuthenticationToken authentication =
-				new UsernamePasswordAuthenticationToken(userId, null, null);
-			authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+			try{
+				// 1. 토큰 유효성 검증 & userId 추출
+				Long userId = tokenService.extractUserId(token);
+				// 2. 인증 객체 생성 후 SecurityContext에 저장
+				UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(userId, null, null);
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+				SecurityContextHolder.getContext().setAuthentication(authentication);
 
-			SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+
+			catch(AuthBusinessException e){
+				ErrorCode errorCode = e.getErrorCode();
+				response.setStatus(errorCode.getStatus().value());
+				response.setContentType("application/json;charset=UTF-8");
+
+				objectMapper.writeValue(response.getWriter(), Map.of(
+						"code", errorCode.getCode(),
+						"message", errorCode.getMessage()
+				));
+				return;
+			}
 		}
-
 		filterChain.doFilter(request, response);
 	}
 


### PR DESCRIPTION
## 📌 PR 제목
JwtAuthenticationFilter에서 인증 예외를 공통 에러 포맷으로 처리

---

## ✨ 요약 설명
JWT 인증 과정에서 발생하는 예외(AuthBusinessException)가 필터 레벨에서 처리되지 않아 500 서버 에러 및 톰캣 ERROR 로그로 노출되던 문제를 수정했습니다.
인증 실패 시 공통 에러 포맷과 HTTP 401 상태 코드로 응답하도록 처리하여, 프론트엔드에서 refresh 토큰 재발급 플로우를 정상적으로 트리거할 수 있도록 개선했습니다.

---

## 🧾 변경 사항
- JwtAuthenticationFilter에서 JWT 검증 중 발생하는 AuthBusinessException을 직접 처리하도록 수정
- 만료 토큰, 서명 오류 등 인증 관련 예외가 500이 아닌 401로 내려가도록 개선
(JwtAuthenticationFilter.java / TokenService.java (JWT 예외 코드 분기 처리))
---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #240 
- Fix #240 