### PR TITLE
[fix]ImageDomain 상수 누락으로 인한 Presigned URL 발급 에러 해결

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/api/controller/ImageController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/api/controller/ImageController.java
@@ -41,7 +41,7 @@ public class ImageController {
 	public ResponseEntity<ApiResponse<IssuePresignedUrlResponseDTO>> issuePresignedUrl(
 		@RequestBody IssuePresignedUrlRequestDTO request
 	) {
-		ImageDomain domain = ImageDomain.valueOf(request.domain().toUpperCase());
+		ImageDomain domain = request.getDomainEnum();
 		IssuePresignedUrlResult result = presignedImageService.createPresignedUrl(domain,request.contentType());
 
 		return ResponseEntity.ok(ApiResponse.success(IssuePresignedUrlResponseDTO.from(result)));
@@ -57,7 +57,7 @@ public class ImageController {
 				request.contentType(),
 				request.width(),
 				request.height(),
-				ImageDomain.valueOf(request.domain().toUpperCase())
+			    request.getDomainEnum()
 			)
 		);
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/api/dto/request/ImageRegisterRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/api/dto/request/ImageRegisterRequestDto.java
@@ -1,8 +1,13 @@
 package org.sopt.pawkey.backendapi.domain.image.api.dto.request;
 
-public record ImageRegisterRequestDto( String imageUrl,
-									   String contentType,
-									   int width,
-									   int height,
-									   String domain) {
+import org.sopt.pawkey.backendapi.domain.image.domain.ImageDomain;
+
+public record ImageRegisterRequestDto(String imageUrl,
+									  String contentType,
+									  int width,
+									  int height,
+									  String domain) {
+	public ImageDomain getDomainEnum() {
+		return ImageDomain.from(this.domain);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/api/dto/request/IssuePresignedUrlRequestDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/api/dto/request/IssuePresignedUrlRequestDTO.java
@@ -1,8 +1,14 @@
 package org.sopt.pawkey.backendapi.domain.image.api.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import org.sopt.pawkey.backendapi.domain.image.domain.ImageDomain;
 
 public record IssuePresignedUrlRequestDTO(
 	@NotBlank String domain,      // route, profile , walk...
 	@NotBlank String contentType
-) {}
+) {
+	public ImageDomain getDomainEnum(){
+		return ImageDomain.from(this.domain);
+
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/domain/ImageDomain.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/domain/ImageDomain.java
@@ -1,9 +1,13 @@
 package org.sopt.pawkey.backendapi.domain.image.domain;
 
+import org.sopt.pawkey.backendapi.domain.image.exception.ImageBusinessException;
+import org.sopt.pawkey.backendapi.domain.image.exception.ImageErrorCode;
+import org.sopt.pawkey.backendapi.global.exception.ErrorCode;
+
 public enum ImageDomain { //S3 경로의 최상위 prefix로 사용({domain}/{uuid}.{ext})
 	WALK("walk"),
 	ROUTE("route"),
-	PROFILE("profile");
+	PET_PROFILE("profile");
 
 	private final String path;
 
@@ -13,6 +17,19 @@ public enum ImageDomain { //S3 경로의 최상위 prefix로 사용({domain}/{uu
 
 	public String getPath() {
 		return path;
+	}
+
+	public static ImageDomain from(String domainStr) {
+		if (domainStr == null || domainStr.isBlank()) {
+			throw new ImageBusinessException(ImageErrorCode.INVALID_IMAGE_DOMAIN);
+		}
+
+		try {
+			return ImageDomain.valueOf(domainStr.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			// PET_PROFILE, WALK 등이 아닌 값이 들어오면 정의된 400 에러 코드를 반환
+			throw new ImageBusinessException(ImageErrorCode.INVALID_IMAGE_DOMAIN);
+		}
 	}
 
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] ImageDomain 상수 누락으로 인한 Presigned URL 발급 에러 해결
---

## ✨ 요약 설명
이미지 업로드용 Presigned URL 발급 시, 클라이언트가 전달하는 PET_PROFILE 등의 도메인 상수가 서버의 ImageDomain Enum에 정의되어 있지 않아 발생하던 500 Internal Server Error(IllegalArgumentException)를 해결했습니다.

---

## 🧾 변경 사항

- ImageDomain (Enum):

  - PET_PROFILE 상수 추가 및 S3 경로("profile") 매핑
  - 문자열을 안전하게 Enum으로 변환해주는 정적 팩토리 메서드 from() 구현
 
- IssuePresignedUrlRequestDTO & ImageRegisterRequestDto (DTO):
  - 컨트롤러 로직 캡슐화를 위해 getDomainEnum() 메서드 추가

- ImageController
  - valueOf() 대신 from() 또는 DTO 메서드를 사용하여 런타임 에러 방지 및 예외 처리 로직 강화

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 PET_PROFILE 도메인 요청 시 200 OK 확인
- [ ] 정의되지 않은 도메인 요청 시 ImageErrorCode.INVALID_IMAGE_DOMAIN(R40001) 반환 확인

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호