### PR TITLE
[Fix] presigned GET URL 적용하여, Private S3 이미지 조회 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/application/service/PresignedImageService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/application/service/PresignedImageService.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.image.application.service;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -8,8 +9,11 @@ import org.sopt.pawkey.backendapi.domain.image.domain.ImageDomain;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -25,6 +29,24 @@ public class PresignedImageService {
 	@Value("${cloud.presign.expire-minutes}")
 	private long expireMinutes;
 
+	public String createPresignedGetUrl(String s3ImageUrl) {
+		String key = URI.create(s3ImageUrl).getPath().substring(1);
+
+		GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.build();
+
+		PresignedGetObjectRequest presignedRequest =
+				s3Presigner.presignGetObject(
+						GetObjectPresignRequest.builder()
+								.getObjectRequest(getObjectRequest)
+								.signatureDuration(Duration.ofMinutes(expireMinutes))
+								.build()
+				);
+
+		return presignedRequest.url().toString();
+	}
 
 	public IssuePresignedUrlResult createPresignedUrl(ImageDomain domain, String contentType){
 		String key = generateKey(domain,contentType); //key(식별자) 생성

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/api/dto/response/PetProfileResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/api/dto/response/PetProfileResponseDto.java
@@ -18,10 +18,11 @@ public record PetProfileResponseDto(
 	String dbtiName,
 	String dbtiDescription
 ) {
-	public static PetProfileResponseDto of(PetEntity pet, String formattedAge, String dbtiDescription) {
+	//imageUrl을 외부에서 주입받도록 시그니처 변경
+	public static PetProfileResponseDto of(PetEntity pet, String imageUrl,String formattedAge, String dbtiDescription) {
 		return new PetProfileResponseDto(
 			pet.getPetId(),
-			pet.getProfileImage() != null ? pet.getProfileImage().getImageUrl() : null,
+			imageUrl,
 			pet.getName(),
 			pet.getBirth(),
 			formattedAge,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/facade/PetQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/facade/PetQueryFacade.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.dbti.application.service.DbtiQueryService;
 import org.sopt.pawkey.backendapi.domain.dbti.infra.persistence.entity.DbtiEntity;
+import org.sopt.pawkey.backendapi.domain.image.application.service.PresignedImageService;
 import org.sopt.pawkey.backendapi.domain.pet.api.dto.response.BreedListResponseDto;
 import org.sopt.pawkey.backendapi.domain.pet.api.dto.response.PetProfileResponseDto;
 import org.sopt.pawkey.backendapi.domain.pet.application.service.PetQueryService;
@@ -20,6 +21,7 @@ public class PetQueryFacade {
 
 	private final PetQueryService petQueryService;
 	private final DbtiQueryService dbtiQueryService;
+	private final PresignedImageService presignedImageService;
 
 	public BreedListResponseDto getBreedList() {
 		List<BreedListResponseDto.BreedDto> breeds = petQueryService.getAllBreeds();
@@ -35,7 +37,10 @@ public class PetQueryFacade {
 			DbtiEntity dbti = dbtiQueryService.getDbtiInfo(pet.getDbtiResult().getDbtiType());
 			dbtiName = dbti.getName();
 		}
+		String imageUrl = pet.getProfileImage() != null
+				? presignedImageService.createPresignedGetUrl(pet.getProfileImage().getImageUrl())
+				: null;
 
-		return PetProfileResponseDto.of(pet, formattedAge, dbtiName);
+		return PetProfileResponseDto.of(pet, imageUrl, formattedAge, dbtiName);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/facade/query/PostQueryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/facade/query/PostQueryFacade.java
@@ -2,6 +2,7 @@ package org.sopt.pawkey.backendapi.domain.post.application.facade.query;
 
 import java.util.List;
 
+import org.sopt.pawkey.backendapi.domain.image.application.service.PresignedImageService;
 import org.sopt.pawkey.backendapi.domain.image.domain.model.ImageType;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.request.FilterPostsRequestDto;
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostCardResponseDto;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class PostQueryFacade {
 	private final PostQueryService postQueryService;
 	private final PostService postService;
+	private final PresignedImageService presignedImageService;
 
 	public PostListResponseDto getFilterPostList(FilterPostsRequestDto requestDto, Long userId) {
 		List<GetPostCardResult> results = postQueryService.getFilteredPosts(requestDto, userId);
@@ -41,12 +43,16 @@ public class PostQueryFacade {
 			.anyMatch(like -> like.getUser().getUserId().equals(userId));
 
 		String routeMapImageUrl =
-			post.getRoute().getTrackingImage() != null ? post.getRoute().getTrackingImage().getImageUrl() : null;
+				post.getRoute().getTrackingImage() != null
+						? presignedImageService.createPresignedGetUrl(
+						post.getRoute().getTrackingImage().getImageUrl()
+				)
+						: null;
 
 		List<String> walkingImages = post.getPostImageEntityList().stream()
-			.filter(img -> img.getImageType() == ImageType.WALK_POST)
-			.map(img -> img.getImage().getImageUrl())
-			.toList();
+				.filter(img -> img.getImageType() == ImageType.WALK_POST)
+				.map(img -> presignedImageService.createPresignedGetUrl(img.getImage().getImageUrl()))
+				.toList();
 
 		return postQueryService.getPostDetail(post, isLiked, routeMapImageUrl, walkingImages);
 	}


### PR DESCRIPTION
## 📌 PR 제목
[Fix] presigned GET URL 적용하여, Private S3 이미지 조회 오류 수정

---

## ✨ 요약 설명
Private S3 환경에서 원본 이미지 URL로 조회 시 AccessDenied가 발생하던 문제를 해결했습니다.
이미지 업로드/등록 API 구조는 유지한 채, 조회 응답 생성 시 Presigned GET URL로 변환하여 클라이언트에서 정상적으로 이미지를 조회할 수 있도록 수정했습니다.

---

## 🧾 변경 사항
- 이미지 조회 응답 생성 시 S3 원본 URL → Presigned GET URL로 변환 로직 추가
- 펫 프로필 조회 시 이미지 URL 가공 로직 반영
- 관련 Facade 계층 수정

---

## 📂 PR 타입
- [] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호