### PR TITLE
[deploy] CI/CD workflow 분리 및 NCP 개발 서버 환경 구축

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,0 +1,43 @@
+name: CI/CD - Dev (NCP)
+on:
+  workflow_dispatch:
+    inputs:
+      branch: { description: 'Branch', required: true, default: 'develop' }
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - uses: actions/setup-java@v3
+        with: { distribution: 'temurin', java-version: '17' }
+      - name: Generate Configs
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.CD_APPLICATION_DEV }}" > ./src/main/resources/application.yml
+          echo "${{ secrets.CD_APPLICATION_AWS }}" > ./src/main/resources/application-aws.yml
+          echo "${{ secrets.CD_APPLICATION_OAUTH }}" > ./src/main/resources/application-oauth.yml
+      - name: Build & Push
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          docker build -t "${{ secrets.DOCKER_USERNAME }}/pawkey-dev:latest" .
+          docker push "${{ secrets.DOCKER_USERNAME }}/pawkey-dev:latest"
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_NCP_PROD_IP }}
+          username: root
+          password: ${{ secrets.DEV_NCP_PASSWORD }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USERNAME }}/pawkey-dev:latest
+            docker rm -f pawkey-dev-container || true
+            docker run -d -p 8080:8080 --name pawkey-dev-container \
+              --network host \
+              -e SPRING_PROFILES_ACTIVE=dev \
+              -e DB_PASSWORD_DEV=${{ secrets.DB_PASSWORD_DEV }} \
+              -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+              -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+              ${{ secrets.DOCKER_USERNAME }}/pawkey-dev:latest

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,88 @@
+name: CI/CD - Prod (AWS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy (usually main/master)'
+        required: true
+        default: 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Generate Production YML Files
+        shell: bash
+        run: |
+          mkdir -p ./src/main/resources
+          # 운영 서버용 메인 설정 (AWS RDS 주소 포함)
+          cat <<'EOF' > ./src/main/resources/application.yml
+          ${{ secrets.CD_APPLICATION }}
+          EOF
+          # 공통 AWS 및 OAuth 설정
+          cat <<'EOF' > ./src/main/resources/application-aws.yml
+          ${{ secrets.CD_APPLICATION_AWS }}
+          EOF
+          cat <<'EOF' > ./src/main/resources/application-oauth.yml
+          ${{ secrets.CD_APPLICATION_OAUTH }}
+          EOF
+
+      - name: Build Project
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      - name: Docker Login & Push (Prod Tag)
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          # 👈 태그를 pawkey-prod로 명확히 분리
+          docker build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/pawkey-prod:latest" .
+          docker push "${{ secrets.DOCKER_USERNAME }}/pawkey-prod:latest"
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create SSH Key File
+        run: |
+          # 👈 새로 등록한 PROD 전용 PEM 키 시크릿 사용
+          echo "${{ secrets.PROD_EC2_SSH_KEY }}" > prod_key.pem
+          chmod 600 prod_key.pem
+
+      - name: Deploy to AWS EC2
+        run: |
+          # 👈 PROD 전용 탄력적 IP 사용
+          ssh -o StrictHostKeyChecking=no -i prod_key.pem ubuntu@${{ secrets.PROD_EC2_PUBLIC_IP }} << EOF
+            echo "📦 Pulling latest prod image..."
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/pawkey-prod:latest
+
+            echo "🗑 Cleaning up old containers..."
+            # 기존 dev 이름과 새로운 prod 이름을 모두 체크하여 삭제
+            sudo docker rm -f pawkey-dev-container || true
+            sudo docker rm -f pawkey-prod-container || true
+
+            echo "🚀 Running new production container..."
+            sudo docker run -d -p 8080:8080 \
+              --name pawkey-prod-container \
+              --network pawkey-net \
+              -e SPRING_PROFILES_ACTIVE=aws \
+              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              -e DOKI_JWT_SECRET_VALUE=${{ secrets.DOKI_JWT_SECRET_VALUE }} \
+              ${{ secrets.DOCKER_USERNAME }}/pawkey-prod:latest
+
+            echo "🔄 Reloading Nginx..."
+            sudo nginx -t && sudo systemctl reload nginx
+            echo "✅ AWS Prod Deployment Complete!"
+          EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 
-COPY build/libs/*.jar pawkey-dev.jar
+COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "pawkey-dev.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 📌 PR 제목
[deploy] CI/CD workflow 분리 및 NCP 개발 서버 환경 구축

---

## ✨ 요약 설명
기존 AWS(Prod) 단일 환경에서 운영되던 인프라를 AWS(운영/Prod)와 NCP(개발/Dev) 환경으로 명확히 분리하고, 각 환경에 최적화된 자동 배포 파이프라인을 구축했습니다.

---

## 🧾 변경 사항
1. 배포 워크플로우 분리
- `.github/workflows/prod-deploy.yml`: AWS 운영 서버 배포 (PEM Key 인증 방식 유지)
- `.github/workflows/dev-deploy.yml`: NCP 개발 서버 배포 (SSH Password 인증 방식 적용)

2.  Dockerfile 변경
실행 JAR 파일 명칭을 app.jar로 통일


---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 기타 (직접 작성:인프라 구축 및 CI/CD 환경 분리 )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
배포 방식 차이: AWS는 기존 방식대로 .pem 키를 사용하고, NCP는 보안 정책에 따라 관리자 비밀번호 방식을 사용하도록 구현했습니다.

이미지 태그: 이제 운영 환경은 pawkey-prod, 개발 환경은 pawkey-dev 이미지를 사용하므로 서버 터미널에서 docker ps 시 혼동 없으시길 바랍니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호