### PR TITLE
[bug] 내가 작성한 후기 리스트 조회 시 날짜 필드 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/ReviewCardResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/response/ReviewCardResponseDto.java
@@ -23,7 +23,7 @@ public record ReviewCardResponseDto(
 			post.getPostId(),
 			post.getTitle(),
 			route.getRegion().getFullRegionName(),
-			review.getCreatedAt(),
+			post.getCreatedAt(),
 			post.getPostSelectedCategoryOptionEntityList().stream()
 				.map(sel -> sel.getCategoryOption().getOptionValue())
 				.toList()


### PR DESCRIPTION
## 📌 PR 제목
[bug] 내가 작성한 후기 리스트 조회 시 날짜 필드 오류 수정

---

## ✨ 요약 설명
마이페이지 '내가 작성한 후기 리스트 조회' API 응답 시, 작성 날짜가 후기 생성일이 아닌 원본 게시글 생성일로 나오도록 수정했습니다.

---

## 🧾 변경 사항
- ReviewCardResponseDto 수정: date 필드에 매핑되는 데이터를 review.getCreatedAt()에서 post.getCreatedAt()으로 변경

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- fromReview 정적 팩토리 메서드 내부의 매핑 로직만 간단히 수정되었습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #268 
- Fix #268 