### PR TITLE
[feat] 닉네임 중복 검사 api 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -20,6 +20,7 @@ import org.sopt.pawkey.backendapi.domain.user.application.facade.command.UpdateU
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserLikedPostQueryFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserQueryFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserWrittenPostQueryFacade;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -64,6 +66,23 @@ public class UserController {
 		UserOnboardingResponseDto response = userOnboardingFacade.onboard(userId, command);
 
 		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	private final UserService userService;
+
+	@Operation(summary = "닉네임 중복 검사", description = "파라미터로 받은 닉네임의 중복 여부를 확인합니다.", tags = {"Users"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용 가능한 닉네임 (S000)"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "중복된 닉네임 (U40901)", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@GetMapping
+	public ResponseEntity<ApiResponse<Void>> checkNicknameDuplicate(
+		@Parameter(hidden = true) @UserId Long userId,
+		@RequestParam("nickname") String nickname
+	) {
+		userService.isNicknameDuplicated(userId, nickname);
+		return ResponseEntity.ok(ApiResponse.success());
 	}
 
 	@Operation(summary = "내가 좋아요한 게시물 조회", description = "사용자가 좋아요를 누른 게시물 목록을 반환합니다.", tags = {"Users"})

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -34,7 +34,11 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public void isNicknameDuplicated(Long userId, String nickname) {
-		findById(userId);
+		UserEntity user = findById(userId);
+
+		if (nickname.equals(user.getName())) {
+			return;
+		}
 		if (userRepository.existsByName(nickname)) {
 			throw new UserBusinessException(UserErrorCode.USER_DUPLICATE_NICKNAME);
 		}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -32,6 +32,14 @@ public class UserService {
 			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
 	}
 
+	@Transactional(readOnly = true)
+	public void isNicknameDuplicated(Long userId, String nickname) {
+		findById(userId);
+		if (userRepository.existsByName(nickname)) {
+			throw new UserBusinessException(UserErrorCode.USER_DUPLICATE_NICKNAME);
+		}
+	}
+
 	@Transactional
 	public UserEntity completeOnboarding(Long userId, OnboardingInfoCommand command, RegionEntity region) {
 


### PR DESCRIPTION
## 📌 PR 제목
[feat] 닉네임 중복 검사 api 추가

---

## ✨ 요약 설명
소셜 로그인 직후 진행되는 온보딩 과정에서 사용자가 입력한 닉네임의 중복 여부를 바로 확인할 수 있는 API를 추가했습니다.

---

## 🧾 변경 사항
- **API 추가**: GET /api/v1/users?nickname
- **UserService 로직 구현**: validateNicknameDuplication = 현재 접속 중인 userId의 존재 여부를 검증하고 existsByName을 통해 중복을 판단
- **파일 변경**: UserController.java, UserService.java,

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- **동시성 고민**: 해당 서비스 레이어에서 1차 중복 검증을 수행합니다. 추후 온보딩 최종 완료(POST) 시점에 한 번 더 검증하여 찰나의 동시 가입 문제를 방어하는데 적절한지 확인해주시면 감사하겠습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #270 
- Fix #270 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 닉네임 중복 검증 기능이 추가되었습니다. 사용자가 계정 설정 또는 닉네임 변경 시 해당 닉네임이 이미 사용 중인지 즉시 확인할 수 있으며, 중복되는 경우 시스템이 자동으로 이를 감지하여 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->