### PR TITLE
[fix] 회원 탈퇴 시 FK 제약으로 인한 삭제 실패 문제 해결

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostRepository.java
@@ -25,4 +25,6 @@ public interface PostRepository {
 	Optional<PostEntity> findByRoute(RouteEntity route);
 
 	List<PostEntity> findAllByRouteIds(List<Long> routeIds);
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostRepositoryImpl.java
@@ -63,4 +63,10 @@ public class PostRepositoryImpl implements PostRepository {
 		}
 		return jpaRepository.findByRouteRouteIdInAndIsPublicTrue(routeIds);
 	}
+
+	@Override
+	public void deleteByUserId(Long userId) {
+		jpaRepository.deleteByUser_UserId(userId);
+	}
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
@@ -63,4 +63,7 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
 	List<PostEntity> findByRouteRouteIdIn(List<Long> routeIds);
 
 	List<PostEntity> findByRouteRouteIdInAndIsPublicTrue(List<Long> routeIds);
+
+	@Modifying
+	void deleteByUser_UserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/domain/repository/RouteRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/domain/repository/RouteRepository.java
@@ -14,4 +14,6 @@ public interface RouteRepository {
 	HomeInfoResponseDto getMonthlyWalkSummary(Long userId);
 
 	List<RouteEntity> findAllById(List<Long> ids);
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/RouteRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/RouteRepositoryImpl.java
@@ -39,4 +39,11 @@ public class RouteRepositoryImpl implements RouteRepository {
 
 		return jpaRepository.findAllByIdIn(ids);
 	}
+
+	@Override
+	public void deleteByUserId(Long userId) {
+		jpaRepository.deleteByUser_UserId(userId);
+	}
+
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/SpringDataRouteRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/SpringDataRouteRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -24,4 +25,7 @@ public interface SpringDataRouteRepository extends JpaRepository<RouteEntity, Lo
 			"LEFT JOIN FETCH r.trackingImage ti " +
 			"WHERE r.routeId IN :ids")
 	List<RouteEntity> findAllByIdIn(@Param("ids") List<Long> ids);
+
+	@Modifying
+	void deleteByUser_UserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserWithdrawFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserWithdrawFacade.java
@@ -25,14 +25,17 @@ public class UserWithdrawFacade {
 
 		//revoke 토큰 조회
 		String revokeToken = socialAccountService.getRevokeToken(userId, provider);
-		//외부 소셜 연동 해제
+
+		tokenService.revokeAllSessions(userId); // 세션 먼저 제거
+		userDeletionService.deleteUser(userId); // DB 삭제
+
+		//외부 소셜 연동 해제(실패해도 탈퇴 성공 유지)
 		try {
 			withdrawServiceFactory.get(provider).withdraw(revokeToken);
 		} catch (Exception e) {
 			log.warn("소셜 연동 해제 실패 => 내부 탈퇴 진행", e);
 		}
-		tokenService.revokeAllSessions(userId);
-		userDeletionService.deleteUser(userId);
+
 	}
 
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
@@ -1,6 +1,8 @@
 package org.sopt.pawkey.backendapi.domain.user.application.service;
 
 import org.sopt.pawkey.backendapi.domain.auth.domain.repository.AppleRefreshTokenRepository;
+import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostRepository;
+import org.sopt.pawkey.backendapi.domain.routes.domain.repository.RouteRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.SocialAccountRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -15,8 +17,16 @@ public class UserDeletionService {
 	private final SocialAccountRepository socialAccountRepository;
 	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 
+	private final PostRepository postRepository;
+	private final RouteRepository routeRepository;
+
 	@Transactional
 	public void deleteUser(Long userId) {
+
+		postRepository.deleteByUserId(userId);
+		routeRepository.deleteByUserId(userId); //post와 route는 cascade설정시, 대량 Lazy Loading이 발생할 수 있어서, service단에서 처리(나머지 pet,review,postlike연관관계는 userEntity에서 casecade로 처리합니다)
+
+
 		appleRefreshTokenRepository.deleteById(userId);
 		socialAccountRepository.deleteByUser_UserId(userId);
 		userRepository.deleteById(userId);


### PR DESCRIPTION
## 📌 PR 제목
[bug] 회원 탈퇴 시 FK 제약으로 인한 users 삭제 실패 문제 해결
---

## ✨ 요약 설명
회원 탈퇴 API 호출 시 users 테이블이 posts, routes 등 FK로 참조되고 있어 삭제가 실패하던 문제를 수정했습니다.
탈퇴 과정에서 사용자와 연관된 일부 도메인 데이터를 먼저 삭제하는 bulk delete 로직을 추가하고, 탈퇴 로직의 실행 순서를 정리하여 데이터 일관성을 개선했습니다.

---

## 🧾 변경 사항
- PostRepository, RouteRepository에 deleteByUserId 메서드 추가
- SpringDataRepository에 deleteByUser_UserId bulk delete 구현
- UserDeletionService 로직 수정 : 탈퇴 시 child 데이터 선 삭제 후 users 삭제하도록 순서 정리
- 탈퇴 로직 순서 개선 : 외부 소셜 revoke 호출을 DB 삭제 이후로 이동하여 데이터 일관성 개선

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #217 
- Fix #217 