### PR TITLE
[fix] 회원 탈퇴 시, 하위 테이블 FK제약으로 인한 유저 삭제 문제 해결

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/dbti/domain/repository/DbtiResultRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/dbti/domain/repository/DbtiResultRepository.java
@@ -8,4 +8,6 @@ public interface DbtiResultRepository {
 	Optional<DbtiResultEntity> findByPetId(Long petId);
 
 	DbtiResultEntity save(DbtiResultEntity result);
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/dbti/infra/persistence/repository/DbtiResultRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/dbti/infra/persistence/repository/DbtiResultRepositoryImpl.java
@@ -19,6 +19,12 @@ public class DbtiResultRepositoryImpl implements DbtiResultRepository {
 	}
 
 	@Override
+	public void deleteByUserId(Long userId) {
+		springDataDbtiResultRepository.deleteByUserId(userId);
+
+	}
+
+	@Override
 	public Optional<DbtiResultEntity> findByPetId(Long petId) {
 		return springDataDbtiResultRepository.findByPet_PetId(petId);
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/dbti/infra/persistence/repository/SpringDataDbtiResultRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/dbti/infra/persistence/repository/SpringDataDbtiResultRepository.java
@@ -2,9 +2,19 @@ package org.sopt.pawkey.backendapi.domain.dbti.infra.persistence.repository;
 
 import java.util.Optional;
 
+import feign.Param;
 import org.sopt.pawkey.backendapi.domain.dbti.infra.persistence.entity.DbtiResultEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SpringDataDbtiResultRepository extends JpaRepository<DbtiResultEntity, Long> {
 	Optional<DbtiResultEntity> findByPet_PetId(Long petId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("""
+        delete from DbtiResultEntity d
+        where d.pet.user.userId = :userId
+    """)
+	void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostSelectedCategoryOptionRepository.java
@@ -8,5 +8,6 @@ import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelec
 public interface PostSelectedCategoryOptionRepository {
 	void saveBatch(List<PostSelectedCategoryOptionEntity> postSelectedCategoryOptions);
 	void deleteByPost(PostEntity post);
+	void deleteByUserId(Long userId);
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostSelectedCategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostSelectedCategoryOptionRepositoryImpl.java
@@ -23,4 +23,9 @@ public class PostSelectedCategoryOptionRepositoryImpl implements PostSelectedCat
 	public void deleteByPost(PostEntity post) {
 		springDataPostSelectedCategoryOptionRepository.deleteByPost(post);
 	}
+
+	@Override
+	public void deleteByUserId(Long userId) {
+		springDataPostSelectedCategoryOptionRepository.deleteByUserId(userId);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
@@ -64,6 +64,6 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
 
 	List<PostEntity> findByRouteRouteIdInAndIsPublicTrue(List<Long> routeIds);
 
-	@Modifying
+	@Modifying(clearAutomatically = true)
 	void deleteByUser_UserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostSelectedCategoryOptionRepository.java
@@ -1,10 +1,20 @@
 package org.sopt.pawkey.backendapi.domain.post.infra.persistence.repository;
 
+import feign.Param;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostSelectedCategoryOptionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface SpringDataPostSelectedCategoryOptionRepository
-	extends JpaRepository<PostSelectedCategoryOptionEntity, Long> {
+public interface SpringDataPostSelectedCategoryOptionRepository extends JpaRepository<PostSelectedCategoryOptionEntity, Long> {
 	void deleteByPost(PostEntity post);
+
+
+	@Modifying(clearAutomatically = true)
+	@Query("""
+        delete from PostSelectedCategoryOptionEntity o
+        where o.post.user.userId = :userId
+    """)
+	void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/SpringDataRouteRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/SpringDataRouteRepository.java
@@ -26,6 +26,6 @@ public interface SpringDataRouteRepository extends JpaRepository<RouteEntity, Lo
 			"WHERE r.routeId IN :ids")
 	List<RouteEntity> findAllByIdIn(@Param("ids") List<Long> ids);
 
-	@Modifying
+	@Modifying(clearAutomatically = true)
 	void deleteByUser_UserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
@@ -1,7 +1,9 @@
 package org.sopt.pawkey.backendapi.domain.user.application.service;
 
 import org.sopt.pawkey.backendapi.domain.auth.domain.repository.AppleRefreshTokenRepository;
+import org.sopt.pawkey.backendapi.domain.dbti.domain.repository.DbtiResultRepository;
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostRepository;
+import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostSelectedCategoryOptionRepository;
 import org.sopt.pawkey.backendapi.domain.routes.domain.repository.RouteRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.SocialAccountRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
@@ -17,18 +19,28 @@ public class UserDeletionService {
 	private final SocialAccountRepository socialAccountRepository;
 	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 
+	private final DbtiResultRepository dbtiResultRepository;
+	private final PostSelectedCategoryOptionRepository postSelectedCategoryOptionRepository;
+
 	private final PostRepository postRepository;
 	private final RouteRepository routeRepository;
 
 	@Transactional
 	public void deleteUser(Long userId) {
 
+		//연관 테이블의 child테이블 우선 삭제
+		dbtiResultRepository.deleteByUserId(userId);
+		postSelectedCategoryOptionRepository.deleteByUserId(userId);
+
+
+		//연관 테이블 삭제
 		postRepository.deleteByUserId(userId);
 		routeRepository.deleteByUserId(userId); //post와 route는 cascade설정시, 대량 Lazy Loading이 발생할 수 있어서, service단에서 처리(나머지 pet,review,postlike연관관계는 userEntity에서 casecade로 처리합니다)
 
 
 		appleRefreshTokenRepository.deleteById(userId);
 		socialAccountRepository.deleteByUser_UserId(userId);
+
 		userRepository.deleteById(userId);
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] 회원 탈퇴 시 FK 제약으로 인한 users 삭제 실패 문제 해결

---

## ✨ 요약 설명
회원 탈퇴 시 `users` 삭제 과정에서 FK로 연결된 하위 테이블 데이터가 먼저 삭제되지 않아 DB에서 foreign key constraint 오류가 발생하는 문제를 수정했습니다.

특히 `posts`, `pets`의 하위 테이블(`post_selected_category_option`, `dbti_result`)이 남아있는 상태에서 parent 삭제가 시도되어 탈퇴 API가 실패하는 문제가 확인되었습니다.

이를 해결하기 위해 탈퇴 시 child 테이블 데이터를 먼저 삭제하는 로직을 추가하고, bulk delete 기반으로 탈퇴 삭제 흐름을 정리했습니다.

---

## 🧾 변경 사항

### 탈퇴 로직 수정
- 회원 탈퇴 시 child → parent 순으로 삭제하도록 로직 수정

### child 데이터 삭제 로직 추가
- `dbti_result` 삭제 로직 추가
- `post_selected_category_option` 삭제 로직 추가

### bulk delete 로직 정리
- `PostRepository`에 user 기준 bulk delete 추가
- `RouteRepository`에 user 기준 bulk delete 추가

### 영속성 컨텍스트 정리
- bulk delete 사용 시 JPA 캐시 불일치 방지를 위해  
`@Modifying(clearAutomatically = true)` 옵션 적용

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 탈퇴 API 호출 확인
- [x] FK 오류 없이 users 삭제 정상 동작 확인
- [x] 연관 테이블 데이터 정상 삭제 확인

---

## ✅ 체크리스트
- [x] 깃 & 코드 컨벤션을 지켰는가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?
- [x] 탈퇴 로직 전체 흐름 테스트 완료

---

## 💬 리뷰어에게 전달할 말
기존 탈퇴 로직에서는 `posts`, `pets` 하위 테이블의 child 데이터가 먼저 삭제되지 않아 FK 제약으로 인해 탈퇴가 실패하는 문제가 있었습니다.

`posts`와 `routes`는 대량 데이터 가능성을 고려하여 cascade 대신 bulk delete로 처리하고 있어,  
child 테이블(`post_selected_category_option`, `dbti_result`)을 먼저 삭제하도록 로직을 추가했습니다.

삭제 순서와 bulk delete 처리 방식 관련하여 더 좋은 설계가 있다면 피드백 부탁드립니다.

---

## 🔗 관련 이슈
Fix #274 