### PR TITLE
[bug] 강아지 프사 null 허용 및 기본 이미지 매핑 하기

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/domain/model/ImageType.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/domain/model/ImageType.java
@@ -1,8 +1,16 @@
 package org.sopt.pawkey.backendapi.domain.image.domain.model;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ImageType {
-	PET_PROFILE,
-	ROUTE,
-	WALK_POST,
-	ETC    // 기타이미지
+
+	PET_PROFILE(1L),
+	ROUTE(null),
+	WALK_POST(null),
+	ETC(null);
+
+	private final Long defaultId;
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/service/PetCommandService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/service/PetCommandService.java
@@ -1,5 +1,6 @@
 package org.sopt.pawkey.backendapi.domain.pet.application.service;
 
+import org.sopt.pawkey.backendapi.domain.image.domain.model.ImageType;
 import org.sopt.pawkey.backendapi.domain.image.domain.repository.ImageRepository;
 import org.sopt.pawkey.backendapi.domain.image.exception.ImageBusinessException;
 import org.sopt.pawkey.backendapi.domain.image.exception.ImageErrorCode;
@@ -37,11 +38,12 @@ public class PetCommandService {
 		BreedEntity breed = breedRepository.findBreedById(command.breedId())
 			.orElseThrow(() -> new PetBusinessException(PetErrorCode.BREED_NOT_FOUND));
 
-		ImageEntity profileImage = null;
-		if (command.imageId() != null) {
-			profileImage = imageRepository.findById(command.imageId())
-				.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
-		}
+		Long finalImageId = (command.imageId() != null)
+			? command.imageId()
+			: ImageType.PET_PROFILE.getDefaultId();
+
+		ImageEntity profileImage = imageRepository.findById(finalImageId)
+			.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
 
 		PetEntity pet = PetEntity.builder()
 			.name(command.name())
@@ -63,10 +65,12 @@ public class PetCommandService {
 			.orElseThrow(() -> new PetBusinessException(PetErrorCode.BREED_NOT_FOUND))
 			: pet.getBreed();
 
-		ImageEntity profileImage = (command.imageId() != null)
-			? imageRepository.findById(command.imageId())
-			.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND))
-			: pet.getProfileImage();
+		Long finalImageId = (command.imageId() != null)
+			? command.imageId()
+			: ImageType.PET_PROFILE.getDefaultId();
+
+		ImageEntity profileImage = imageRepository.findById(finalImageId)
+			.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
 
 		pet.updateProfile(
 			command.name() != null ? command.name() : pet.getName(),


### PR DESCRIPTION
## 📌 PR 제목
[bug] 강아지 프사 null 허용 및 기본 이미지 매핑 하기

---

## ✨ 요약 설명
반려동물 등록 시 프로필 이미지(image_id)가 없는 경우에도 정상적으로 등록될 수 있도록 null 처리를 허용하고, 조회 시에는 시스템 기본 이미지가 매핑되도록 로직을 수정했습니다.

---

## 🧾 변경 사항
- **이미지 ID 선택**: image_id에 대한 필수 조건을 제거하여 null 입력을 허용했습니다.
- **기본 이미지 매핑 로직 추가**: 반려동물 등록 시 image_id가 null인 경우, ImageType.PET_PROFILE에 설정된 defaultId를 사용하여 기본 프로필 이미지가 저장되도록 구현했습니다.
- **예외 처리 수정**: 이미지가 없을 때 발생하던 ImageBusinessException(R40401)이 온보딩 흐름을 방해하지 않도록 방어 로직을 추가했습니다.

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 현재 ImageType.PET_PROFILE의 defaultId가 1L로 설정되어 있는데, 검토 부탁드려요!

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #278 
- Fix #278 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 반려동물 프로필 이미지가 지정되지 않은 경우 기본 이미지가 올바르게 적용되도록 개선
  * 이미지 조회 실패 시 예외 처리 강화로 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->