### PR TITLE
[feat] 지역구 영역 좌표 조회 API 응답 구조 수정 및 유저 지역 수정 API 구현

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/controller/RegionController.java
@@ -2,6 +2,7 @@ package org.sopt.pawkey.backendapi.domain.region.api.controller;
 
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import org.sopt.pawkey.backendapi.domain.auth.annotation.UserId;
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionCoordinatesResponseDto;
 import org.sopt.pawkey.backendapi.domain.region.api.dto.GetRegionListResponseDto;
@@ -57,7 +58,7 @@ public class RegionController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "현재 지역 리스트 조회")
 	})
 	public ResponseEntity<ApiResponse<GetRegionResponseDto>> getCurrentRegion(
-		@UserId Long userId
+			@Parameter(hidden = true) @UserId Long userId
 	) {
 		GetRegionResult result = getRegionFacade.execute(userId);
 
@@ -71,14 +72,17 @@ public class RegionController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "지역 범위 좌표 조회"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "조회 실패 (U40401 또는 R40401 에러코드 확인)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BusinessException.class)))})
 	public ResponseEntity<ApiResponse<GetRegionCoordinatesResponseDto>> getRegionCoordinates(
-		@UserId Long userId,
+		@Parameter(hidden = true) @UserId Long userId,
 		@PathVariable("regionId") Long regionId
 	) {
 
-		GetRegionCoordinatesResult result = getRegionCoordinatesFacade.execute(userId,
-			GetRegionCoordinatesCommand.of(regionId));
+		GetRegionCoordinatesResult result = getRegionCoordinatesFacade.execute(GetRegionCoordinatesCommand.of(regionId));
 
 		return ResponseEntity.ok(
 			ApiResponse.success(GetRegionCoordinatesResponseDto.from(result)));
 	}
+
+
+
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionCoordinatesResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/api/dto/GetRegionCoordinatesResponseDto.java
@@ -8,15 +8,15 @@ import lombok.Builder;
 
 @Builder
 public record GetRegionCoordinatesResponseDto(
-	String regionName,
-	String preRegionName,
-	Map<String, Object> geometryDto
+		Long regionId,
+		String regionName,
+		Map<String, Object> geometry
 ) {
 	public static GetRegionCoordinatesResponseDto from(GetRegionCoordinatesResult result) {
-		return GetRegionCoordinatesResponseDto.builder()
-			.preRegionName(result.preRegionName())
-			.regionName(result.regionName())
-			.geometryDto(result.geometryDto())
-			.build();
+		return new GetRegionCoordinatesResponseDto(
+				result.regionId(),
+				result.regionName(),
+				result.geometry()
+		);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionCoordinatesResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/dto/result/GetRegionCoordinatesResult.java
@@ -8,17 +8,17 @@ import lombok.Builder;
 
 @Builder
 public record GetRegionCoordinatesResult(
+	Long regionId,
 	String regionName,
-	String preRegionName,
-	Map<String, Object> geometryDto
+	Map<String, Object> geometry
 ) {
-	public static GetRegionCoordinatesResult from(String preRegionName, RegionEntity region) {
+	public static GetRegionCoordinatesResult from(RegionEntity region) {
 
 		return GetRegionCoordinatesResult.builder()
-			.preRegionName(preRegionName)
-			.regionName(region.getFullRegionName())
-			.geometryDto(region.getGeoJson())
-			.build();
+				.regionId(region.getRegionId())
+				.regionName(region.getFullRegionName())
+				.geometry(region.getGeoJson())
+				.build();
 	}
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionCoordinatesFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/region/application/facade/query/GetRegionCoordinatesFacade.java
@@ -17,14 +17,12 @@ import lombok.RequiredArgsConstructor;
 public class GetRegionCoordinatesFacade {
 
 	private final RegionService regionService;
-	private final UserService userService;
 
-	public GetRegionCoordinatesResult execute(Long userId,
-		GetRegionCoordinatesCommand getRegionCoordinatesCommand) {
 
-		UserEntity user = userService.findById(userId);
-		RegionEntity region = regionService.getRegionByIdOrThrow(getRegionCoordinatesCommand.regionId());
+	public GetRegionCoordinatesResult execute(GetRegionCoordinatesCommand getRegionCoordinatesCommand) {
 
-		return GetRegionCoordinatesResult.from(user.getRegion().getFullRegionName(), region);
+		RegionEntity region = regionService.getDongTypeRegionByIdOrThrow(getRegionCoordinatesCommand.regionId());
+
+		return GetRegionCoordinatesResult.from(region);
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -173,6 +173,7 @@ public class UserController {
 		ListResponseWrapper<ReviewCardResponseDto> response = userWrittenPostQueryFacade.getMyReviews(userId);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
+
 }
 
 


### PR DESCRIPTION
## 📌 PR 제목
[feat] 지역구 영역 좌표 조회 API 응답 구조 수정 및 유저 지역 수정 API 구현
---

## ✨ 요약 설명
지역 선택 화면에서 지도에 행정구역 영역을 표시하기 위해 지역구 영역 좌표 조회 API의 응답 구조를 명세에 맞게 수정하고,
사용자가 마이페이지 등에서 본인의 지역을 변경할 수 있는 유저 지역 수정 API를 구현했습니다.

---

## 🧾 변경 사항
### 지역구 영역 좌표 조회 API 수정
- RegionEntity의 MultiPolygon 데이터를 GeoJSON 형태로 변환하여 반환
- GetRegionCoordinatesResult : preRegionName 제거 , regionId/regionName/geometry 필드로 단순화
- GetRegionCoordinatesResponseDto : 명세에 맞는 응답 구조로 수정
- GetRegionCoordinatesFacade : 사용자 정보 의존 제거,RegionService를 통해 regionId 기반으로 영역 조회

### 유저 지역 수정 API 구현
- 로그인한 유저의 regionId를 변경하는 기능 추가
- UpdateUserRegionFacade : 유저 조회-> regionId 검증 (동 타입 지역 확인) -> UserEntity.region 업데이트

GeoJsonUtil을 이용한 MultiPolygon → GeoJSON 변환 유지
---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 지역 선택 화면에서 지도에 행정구역 영역을 표시하기 위한 GeoJSON 응답 구조를 명세 기준으로 정리했습니다
- regionId는 동(DONG) 기준으로 전달된다는 가정으로 구현했습니다
- 혹시 GU 단위 regionId 요청이 들어올 가능성이 있다면 validation 추가가 필요할지 의견 부탁드립니다

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #282 
- Fix #이슈번호