### PR TITLE
[bug] 반려견 프로필 이미지 관리 로직 개선 및 imageId: 0 규약 도입

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/image/domain/model/ImageType.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/image/domain/model/ImageType.java
@@ -1,16 +1,9 @@
 package org.sopt.pawkey.backendapi.domain.image.domain.model;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum ImageType {
 
-	PET_PROFILE(1L),
-	ROUTE(null),
-	WALK_POST(null),
-	ETC(null);
-
-	private final Long defaultId;
+	PET_PROFILE,
+	ROUTE,
+	WALK_POST,
+	ETC;
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/api/dto/response/PetProfileResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/api/dto/response/PetProfileResponseDto.java
@@ -9,7 +9,6 @@ import org.sopt.pawkey.backendapi.global.enums.Gender;
 public record PetProfileResponseDto(
 	Long petId,
 	String imageUrl,
-	Long imageId,
 	String name,
 	LocalDate birth,
 	String age,
@@ -24,7 +23,6 @@ public record PetProfileResponseDto(
 		return new PetProfileResponseDto(
 			pet.getPetId(),
 			imageUrl,
-			pet.getProfileImage() != null ? pet.getProfileImage().getImageId() : null,
 			pet.getName(),
 			pet.getBirth(),
 			formattedAge,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/api/dto/response/PetProfileResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/api/dto/response/PetProfileResponseDto.java
@@ -9,6 +9,7 @@ import org.sopt.pawkey.backendapi.global.enums.Gender;
 public record PetProfileResponseDto(
 	Long petId,
 	String imageUrl,
+	Long imageId,
 	String name,
 	LocalDate birth,
 	String age,
@@ -23,6 +24,7 @@ public record PetProfileResponseDto(
 		return new PetProfileResponseDto(
 			pet.getPetId(),
 			imageUrl,
+			pet.getProfileImage() != null ? pet.getProfileImage().getImageId() : null,
 			pet.getName(),
 			pet.getBirth(),
 			formattedAge,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/service/PetCommandService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/service/PetCommandService.java
@@ -38,12 +38,11 @@ public class PetCommandService {
 		BreedEntity breed = breedRepository.findBreedById(command.breedId())
 			.orElseThrow(() -> new PetBusinessException(PetErrorCode.BREED_NOT_FOUND));
 
-		Long finalImageId = (command.imageId() != null)
-			? command.imageId()
-			: ImageType.PET_PROFILE.getDefaultId();
-
-		ImageEntity profileImage = imageRepository.findById(finalImageId)
-			.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
+		ImageEntity profileImage = null;
+		if (command.imageId() != null) {
+			profileImage = imageRepository.findById(command.imageId())
+				.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
+		}
 
 		PetEntity pet = PetEntity.builder()
 			.name(command.name())
@@ -65,15 +64,12 @@ public class PetCommandService {
 			.orElseThrow(() -> new PetBusinessException(PetErrorCode.BREED_NOT_FOUND))
 			: pet.getBreed();
 
-		Long finalImageId = (command.imageId() != null)
-			? command.imageId()
-			: (pet.getProfileImage() != null
-			? pet.getProfileImage().getImageId()
-			: ImageType.PET_PROFILE.getDefaultId());
-
-		ImageEntity profileImage = imageRepository.findById(finalImageId)
-			.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
-
+		ImageEntity profileImage = null;
+		if (command.imageId() != null) {
+			profileImage = imageRepository.findById(command.imageId())
+				.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
+		}
+		
 		pet.updateProfile(
 			command.name() != null ? command.name() : pet.getName(),
 			command.birth() != null ? command.birth() : pet.getBirth(),

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/service/PetCommandService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/pet/application/service/PetCommandService.java
@@ -64,12 +64,17 @@ public class PetCommandService {
 			.orElseThrow(() -> new PetBusinessException(PetErrorCode.BREED_NOT_FOUND))
 			: pet.getBreed();
 
-		ImageEntity profileImage = null;
+		ImageEntity profileImage = pet.getProfileImage();
+
 		if (command.imageId() != null) {
-			profileImage = imageRepository.findById(command.imageId())
-				.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
+			if (command.imageId() == 0) {
+				profileImage = null;
+			} else {
+				profileImage = imageRepository.findById(command.imageId())
+					.orElseThrow(() -> new ImageBusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
+			}
 		}
-		
+
 		pet.updateProfile(
 			command.name() != null ? command.name() : pet.getName(),
 			command.birth() != null ? command.birth() : pet.getBirth(),


### PR DESCRIPTION
## 📌 PR 제목
[bug] 반려견 프로필 이미지 관리 로직 개선 및 imageId: 0 규약 도입

---

## ✨ 요약 설명
반려견 프로필 이미지 관리 시 불필요한 기본 이미지(defaultId) 의존성을 제거하고, 클라이언트와 협의된 imageId: 0 규약을 도입했습니다.

---

## 🧾 변경 사항
- **조회 응답 개선** (PetProfileResponseDto): 프로필 이미지가 없을 경우 클라이언트가 기본 이미지를 띄울 수 있도록 합니다.
- **수정 로직 수정** (PetCommandService.savePet): imageId가 0인 경우 프로필 이미지를 초기화 합니다.

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 수정 API에서 imageId가 null일 때(요청 누락) 기존 상태를 유지하고, 0일 때만 명시적으로 비우는 로직이 안전하게 구현되었는지 봐주세요.
- 참고사항: 타 API 연동 작업의 효율을 위해 기존의 복잡한 ImageType 의존성을 제거하고 0을 활용한 최소 변경 방식을 적용했습니다.
---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #284 
- Fix #284 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 반려동물 프로필 이미지 처리 방식을 개선했습니다. 이제 기본 이미지 자동 할당이 제거되었으며, 사용자가 명시적으로 프로필 이미지를 제거할 수 있습니다.

## 리팩토링
- 이미지 타입 구조를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->