### PR TITLE
[fix] 게시물 등록 시 route에 imageId 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/facade/command/PostRegisterFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/facade/command/PostRegisterFacade.java
@@ -66,6 +66,7 @@ public class PostRegisterFacade {
 
 		//Post - Image 연관관계 설정
 		post.addRouteImage(routeImage);     // 내부에서 ImageType.ROUTE로 매핑
+		route.assignTrackingImage(routeImage);
 		post.addWalkImages(walkImages);     // 내부에서 ImageType.WALK_POST로 매핑
 
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostRepository.java
@@ -30,4 +30,7 @@ public interface PostRepository {
 
 	void deleteByRouteUserId(Long userId);
 
+	void deletePostImagesByRouteUserId(Long userId);
+	void deletePostImagesByUserId(Long userId);
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostRepositoryImpl.java
@@ -73,4 +73,13 @@ public class PostRepositoryImpl implements PostRepository {
 		jpaRepository.deleteByRouteUserId(userId);
 	}
 
+	@Override
+	public void deletePostImagesByRouteUserId(Long userId) {
+		jpaRepository.deletePostImagesByRouteUserId(userId);
+	}
+
+	@Override
+	public void deletePostImagesByUserId(Long userId) {
+		jpaRepository.deletePostImagesByUserId(userId);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
@@ -87,4 +87,12 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
     """)
 	void deleteByUserId(@Param("userId") Long userId);
 
+	@Modifying
+	@Query("DELETE FROM PostImageEntity pi WHERE pi.post.route.user.userId = :userId")
+	void deletePostImagesByRouteUserId(@Param("userId") Long userId);
+
+	@Modifying
+	@Query("DELETE FROM PostImageEntity pi WHERE pi.post.user.userId = :userId")
+	void deletePostImagesByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
@@ -95,4 +95,8 @@ public class RouteEntity extends BaseEntity {
 	public int getDurationMinutes() {
 		return (int)(this.duration / 60);
 	}
+
+	public void assignTrackingImage(ImageEntity image) {
+		this.trackingImage = image;
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/walk/application/service/WalkStreamService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/walk/application/service/WalkStreamService.java
@@ -30,12 +30,10 @@ public class WalkStreamService {
 			throw new WalkBusinessException(WalkErrorCode.ALREADY_IN_WALK);
 		}
 		//2. 세션 생성
-		//스트리밍 중 임시식별자이므로 -> String
 		long startedAt = System.currentTimeMillis();
 		String routeId = redisRepository.createSession(command.userId(), command.deviceInfo(),startedAt);
 
-
-		//3. ACTIVE 세션 바인딩(TTL)
+		//3. ACTIVE 세션(TTL)
 		redisRepository.bindActiveSession( 
 			command.userId(),routeId, Duration.ofHours(5).toSeconds()
 		);
@@ -69,26 +67,17 @@ public class WalkStreamService {
 	public WalkSession end(EndWalkCommand command){
 		String routeId = command.routeId();
 
-		//(추가)
-		//0. 세션 로드 + 소유권 검증
-
-		// 1. 세션 로드
 		WalkSession session = redisRepository.loadSession(routeId);
 
-		// 2. 소유권 검증
 		if (!session.getUserId().equals(command.userId())) {
 			throw new WalkBusinessException(WalkErrorCode.INVALID_SESSION_OWNER);
 		}
 
-		// 3. 세션 종료 처리 (Redis 상태 업데이트)
 		redisRepository.endSession(routeId);
 
-		// 4. ACTIVE 세션 해지
 		redisRepository.clearActiveSession(command.userId());
 
 		return session;
-
 	}
-
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
@@ -36,24 +36,28 @@ public class UserDeletionService {
 
 		// 1 option
 		postSelectedCategoryOptionRepository.deleteByUserId(userId);
-
 		entityManager.flush();
 
-		// 2 posts
+		// 2. post_image 먼저 (FK 자식)
+		postRepository.deletePostImagesByRouteUserId(userId);
+		postRepository.deletePostImagesByUserId(userId);
+		entityManager.flush();
+
+		// 3. posts
 		postRepository.deleteByRouteUserId(userId);
 		postRepository.deleteByUserId(userId);
 		entityManager.flush();
 
-		// 3 routes
+		// 4. routes
 		routeRepository.deleteByUserId(userId);
 		entityManager.flush();
 
-		// 4 기타
+		// 5. 기타
 		dbtiResultRepository.deleteByUserId(userId);
 		appleRefreshTokenRepository.deleteById(userId);
 		socialAccountRepository.deleteByUser_UserId(userId);
 
-		// 5 user
+		// 6. user
 		userRepository.deleteById(userId);
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] 게시물 등록 시 route에 imageId 추가
---

## ✨ 요약 설명
게시글 등록 시, 트래킹이미지가 route테이블에 저장되지 않아, 산책 게시물 리스트 조회시에 클라이언트에서 이미지  디코딩이 안되는 문제가 발생해서 해결

---

## 🧾 변경 사항
- 무엇을 추가/수정/삭제했나요?
- 어떤 파일 또는 모듈이 변경되었나요?

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호