### PR TITLE
[fix] 타 사용자 경로 좌표 조회 시 소유권 검증 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteGeometryFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/facade/query/GetRouteGeometryFacade.java
@@ -20,8 +20,6 @@ public class GetRouteGeometryFacade {
         UserEntity user = userService.findById(userId);
         RouteEntity route = routeService.getRouteById(commandDto.routeId());
 
-        route.validateOwnership(user);
-
         return GetRouteGeometryResult.from(route);
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix] 타 사용자 경로 좌표 조회 시 소유권 검증 오류 수정

---

## ✨ 요약 설명
게시글에 연결된 경로를 작성자가 아닌 사용자가 조회할 때 ROUTE_SHOW_FORBIDDEN 예외가 발생하는 버그 수정

---

## 🧾 변경 사항
- GetRouteGeometryFacade에서 route.validateOwnership(user) 호출 제거

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
경로 좌표 조회는 공개 게시글을 통한 접근이므로 소유권 검증이 불필요하다고 판단해 제거했습니다. 게시글 공개 여부 검증이 상위에서 처리되고 있는지 같이 확인 부탁드립니다.

---

- Close #289 
- Fix #289 