### PR TITLE
[feat] 산책 게시물 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/auth/api/controller/AuthController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/auth/api/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.sopt.pawkey.backendapi.domain.auth.application.service.login.verifier
 import org.sopt.pawkey.backendapi.domain.auth.application.service.token.TokenService;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.UserLoginFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.UserWithdrawFacade;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,13 +52,11 @@ public class AuthController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
 	})
 	@PostMapping("/google/login")
-	public SocialLoginResponseDTO googleLogin(@RequestBody @Valid LoginRequestDTO request) {
+	public ResponseEntity<SocialLoginResponseDTO> googleLogin(@RequestBody @Valid LoginRequestDTO request) {
 		// Facade로 ID Token과 Device ID를 전달하여 모든 인증 및 토큰 발급 로직을 처리
-		return userLoginFacade.googleLogin(request.idToken(), request.deviceId());
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(userLoginFacade.googleLogin(request.idToken(), request.deviceId()));
 	}
-
-
-
 
 	// 3. 카카오 로그인 API
 	@Operation(summary = "Kakao 소셜 로그인", description = "Access Token을 받아 사용자 인증 및 Access/Refresh Token을 최초 발급합니다.", tags = {
@@ -69,9 +68,9 @@ public class AuthController {
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
 	})
 	@PostMapping("/kakao/login")
-	public SocialLoginResponseDTO kakaoLogin(@RequestBody @Valid LoginRequestDTO request) {
-		// 카카오는 idToken 대신 Access Token을 받으므로 request.idToken() -> accessToken 개념임
-		return userLoginFacade.kakaoLogin(request.idToken(), request.deviceId());
+	public ResponseEntity<SocialLoginResponseDTO> kakaoLogin(@RequestBody @Valid LoginRequestDTO request) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(userLoginFacade.kakaoLogin(request.idToken(), request.deviceId()));
 	}
 
 	@GetMapping("/kakao/callback") //서버 테스트용 임시 컨트롤러
@@ -93,13 +92,13 @@ public class AuthController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
 	})
 	@PostMapping("/apple/login")
-	public SocialLoginResponseDTO appleLogin(@RequestBody @Valid AppleLoginRequestDTO request) {
-		return userLoginFacade.appleLoginWithCode(
+	public ResponseEntity<SocialLoginResponseDTO> appleLogin(@RequestBody @Valid AppleLoginRequestDTO request) {
+		SocialLoginResponseDTO result = userLoginFacade.appleLoginWithCode(
 			request.authorizationCode(),
 			request.deviceId()
 		);
+		return ResponseEntity.status(HttpStatus.OK).body(result);
 	}
-
 
 	@Operation(summary = "토큰 재발급", description = "Refresh Token과 Device ID를 사용하여 새로운 Access/Refresh Token 쌍을 발급합니다. (토큰 로테이션)", tags = {
 		"Auth"})
@@ -112,7 +111,7 @@ public class AuthController {
 	@PostMapping("/refresh")
 	public ResponseEntity<TokenResponseDTO> refreshToken(@RequestBody @Valid RefreshTokenRequestDTO request) {
 		TokenResponseDTO response = tokenService.rotate(request.refreshToken(), request.deviceId());
-		return ResponseEntity.ok(response);
+		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
 	@Operation(summary = "로그아웃", description = "Access Token에서 사용자 ID를 추출하고, Refresh Token을 Redis에서 삭제하여 현재 기기의 세션을 무효화합니다. 성공 시 204 No Content를 반환합니다.", tags = {
@@ -124,7 +123,7 @@ public class AuthController {
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
 	})
 	@PostMapping("/logout")
-	public ResponseEntity<Void> logout(@Parameter(hidden = true) @UserId Long userId,@RequestBody @Valid LogoutRequestDTO request){
+	public ResponseEntity<Void> logout(@Parameter(hidden = true) @UserId Long userId, @RequestBody @Valid LogoutRequestDTO request) {
 		tokenService.revokeSession(userId, request.deviceId());
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/api/controller/PostController.java
@@ -12,6 +12,7 @@ import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostRegisterRespo
 import org.sopt.pawkey.backendapi.domain.post.api.dto.response.PostResponseDto;
 import org.sopt.pawkey.backendapi.domain.post.application.dto.command.PostRegisterCommand;
 import org.sopt.pawkey.backendapi.domain.post.application.dto.result.PostRegisterResult;
+import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostDeleteFacade;
 import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostRegisterFacade;
 import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostUpdateFacade;
 import org.sopt.pawkey.backendapi.domain.post.application.facade.query.PostQueryFacade;
@@ -42,10 +43,11 @@ public class PostController {
 
 	private final PostRegisterFacade postRegisterFacade;
 	private final PostUpdateFacade postUpdateFacade;
+	private final PostDeleteFacade postDeleteFacade;
 
 	private final PostQueryFacade postQueryFacade;
 
-
+	@Operation(summary = "산책 게시물 등록", description = "산책 완료 후 작성한 산책 게시물을 등록합니다.", tags = {"Posts"})
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시물 조회 성공"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "게시물 ID가 요청에 포함되어 있지 않습니다.", content = @Content(mediaType = "application/json")),
@@ -53,31 +55,38 @@ public class PostController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))})
 
 	@PostMapping
-	@Operation(summary = "산책 게시물 등록", description = "산책 완료 후 작성한 산책 게시물을 등록합니다.", tags = {"Posts"})
 	public ResponseEntity<ApiResponse<PostRegisterResponseDto>> createPost(
 		@Parameter(hidden = true) @UserId Long userId,
 		@RequestBody @Valid PostCreateRequestDto requestDto
 	) {
 		PostRegisterResult result = postRegisterFacade.execute(userId, requestDto.toCommand());
-
-		return ResponseEntity.ok(ApiResponse.success(PostRegisterResponseDto.from(result)));
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(PostRegisterResponseDto.from(result)));
 	}
 
-	@PatchMapping("/{postId}")
+
 	@Operation(summary = "산책 게시물 수정", description = "기존 산책 게시물을 수정합니다.", tags = {"Posts"})
+	@PatchMapping("/{postId}")
 	public ResponseEntity<ApiResponse<PostRegisterResponseDto>> updatePost(
-			@Parameter(hidden = true) @UserId Long userId,
-			@PathVariable Long postId,
-			@RequestBody @Valid PostUpdateRequestDto requestDto
+		@Parameter(hidden = true) @UserId Long userId,
+		@PathVariable Long postId,
+		@RequestBody @Valid PostUpdateRequestDto requestDto
 	) {
-		PostRegisterResult result =
-				postUpdateFacade.execute(userId, postId, requestDto.toCommand());
-
-		return ResponseEntity.ok(ApiResponse.success(PostRegisterResponseDto.from(result)));
+		PostRegisterResult result = postUpdateFacade.execute(userId, postId, requestDto.toCommand());
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(PostRegisterResponseDto.from(result)));
 	}
 
-	@GetMapping("/{postId}")
+	@Operation(summary = "산책 게시물 삭제", description = "기존 산책 게시물을 삭제합니다.", tags = {"Posts"})
+	@DeleteMapping("/{postId}")
+	public ResponseEntity<ApiResponse<Void>> deletePost(
+		@Parameter(hidden = true) @UserId Long userId,
+		@PathVariable Long postId
+	) {
+		postDeleteFacade.execute(userId, postId);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(null));
+	}
+
 	@Operation(summary = "게시물 상세 조회", description = "산책 게시물의 상세정보를 조회합니다.", tags = {"Posts"})
+	@GetMapping("/{postId}")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시물 상세 조회 성공"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/facade/command/PostDeleteFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/facade/command/PostDeleteFacade.java
@@ -1,0 +1,55 @@
+package org.sopt.pawkey.backendapi.domain.post.application.facade.command;
+
+import org.sopt.pawkey.backendapi.domain.image.application.service.command.ImageService;
+import org.sopt.pawkey.backendapi.domain.image.domain.model.ImageType;
+import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class PostDeleteFacade {
+
+	private final PostService postService;
+	private final RouteService routeService;
+	private final ImageService imageService;
+	private final UserService userService;
+
+	public void execute(Long userId, Long postId){
+		PostEntity post = postService.findWithImagesForDelete(postId);
+
+		//작성자(게시물 소유권) 검증
+		UserEntity user = userService.findById(userId);
+		post.validateOwnership(user);
+
+		//산책 이미지 db삭제(s3 삭제는 추후 추가 예정)
+		post.getPostImageEntityList().stream()
+			.filter(img -> img.getImageType() == ImageType.WALK_POST)
+			.forEach(img -> imageService.deleteImageById(img.getImage().getImageId()));
+
+
+		//루트 이미지 db 삭제
+		imageService.deleteImageById(post.getRoute().getTrackingImage().getImageId());
+
+
+		//게시물 삭제
+		postService.delete(post.getPostId());
+
+		//게시물에 매핑된 루트 삭제
+		routeService.delete(post.getRoute().getRouteId());
+
+
+
+
+
+
+
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/service/PostService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/application/service/PostService.java
@@ -25,6 +25,15 @@ public class PostService {
 			.orElseThrow(() -> new PostBusinessException(PostErrorCode.POST_NOT_FOUND));
 	}
 
+	public PostEntity findWithImagesForDelete(Long postId) {
+		return postRepository.findWithImagesForDelete(postId)
+			.orElseThrow(() -> new PostBusinessException(PostErrorCode.POST_NOT_FOUND));
+	}
+
+	public void delete(Long postId) {
+		postRepository.deleteById(postId);
+	}
+
 	public PostEntity savePost(UserEntity writer,
 		PostRegisterCommand command,
 		RouteEntity route) {

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/domain/repository/PostRepository.java
@@ -12,6 +12,9 @@ public interface PostRepository {
 
 	void save(PostEntity post);
 
+	Optional<PostEntity> findWithImagesForDelete(Long postId);
+	void deleteById(Long postId);
+
 	List<PostEntity> findAllByUser(UserEntity user);
 
 	Optional<PostEntity> getPostWithAllDetails(Long postId);

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/exception/PostErrorCode.java
@@ -8,6 +8,7 @@ public enum PostErrorCode implements ErrorCode {
 	POST_NOT_FOUND("P40401", "존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
 	POST_WRITE_FORBIDDEN("P40301", "본인의 경로에 대해서만 게시글 작성이 가능합니다.", HttpStatus.FORBIDDEN),
 	POST_UPDATE_FORBIDDEN("P40302", "본인의 게시글만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+	POST_DELETE_FORBIDDEN("P40303", "본인의 게시글만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
 	ALREADY_ROUTE_POST_EXIST("P40901", "이미 경로에 대한 게시물이 존재합니다.", HttpStatus.CONFLICT),
 	INVALID_FILTER_OPTION("P40001", "유효하지 않은 필터 옵션 값이 포함되어 있습니다.", HttpStatus.BAD_REQUEST),
 	INVALID_CURSOR_FORMAT("P40002", "잘못된 커서 형식입니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/entity/PostEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/entity/PostEntity.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.BatchSize;
 import org.sopt.pawkey.backendapi.domain.image.domain.model.ImageType;
 import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
+import org.sopt.pawkey.backendapi.domain.post.exception.PostBusinessException;
+import org.sopt.pawkey.backendapi.domain.post.exception.PostErrorCode;
 import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
@@ -111,5 +113,12 @@ public class PostEntity extends BaseEntity {
 
 	public void removeWalkImages() {
 		postImageEntityList.removeIf(img -> img.getImageType() == ImageType.WALK_POST);
+	}
+
+	public void validateOwnership(UserEntity user){
+		if(!this.user.equals(user)){
+			throw  new PostBusinessException(PostErrorCode.POST_DELETE_FORBIDDEN);
+		}
+
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/PostRepositoryImpl.java
@@ -27,6 +27,16 @@ public class PostRepositoryImpl implements PostRepository {
 	}
 
 	@Override
+	public Optional<PostEntity> findWithImagesForDelete(Long postId) {
+		return jpaRepository.findWithImagesForDelete(postId);
+	}
+
+	@Override
+	public void deleteById(Long postId) {
+		jpaRepository.deleteById(postId);
+	}
+
+	@Override
 	public List<PostEntity> findAllByUser(UserEntity user) {
 		return jpaRepository.findAllByUser(user);
 	}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
@@ -26,6 +26,11 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
 	})
 	Optional<PostEntity> getByPostId(Long postId);
 
+	@EntityGraph(attributePaths = {"postImageEntityList","postImageEntityList.image","route.trackingImage"})
+	Optional<PostEntity> findWithImagesForDelete(Long postId);
+
+
+
 	@Query("SELECT DISTINCT p FROM PostEntity p " +
 		"LEFT JOIN FETCH p.user u " +
 		"LEFT JOIN FETCH p.pet pt " +
@@ -98,6 +103,9 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
 	@Modifying
 	@Query("DELETE FROM PostLikeEntity pl WHERE pl.post.route.user.userId = :userId OR pl.user.userId = :userId")
 	void deletePostLikesByUserId(@Param("userId") Long userId);
+
+
+
 
 
 

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/service/RouteService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/application/service/RouteService.java
@@ -84,4 +84,8 @@ public class RouteService {
 		return routeRepository.save(route);
 	}
 
+	public void delete(Long routeId) {
+		routeRepository.deleteById(routeId);
+	}
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/domain/repository/RouteRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/domain/repository/RouteRepository.java
@@ -18,4 +18,6 @@ public interface RouteRepository {
 	void deleteByUserId(Long userId);
 
 	List<RouteEntity> findByUserUserId(Long userId);
+
+	void deleteById(Long routeId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/RouteRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/RouteRepositoryImpl.java
@@ -50,5 +50,9 @@ public class RouteRepositoryImpl implements RouteRepository {
 		return jpaRepository.findByUserUserId(userId);
 	}
 
+	@Override
+	public void deleteById(Long routeId) {
+		jpaRepository.deleteById(routeId);
+	}
 
 }

--- a/src/test/java/org/sopt/pawkey/backendapi/domain/post/PostServiceTest.java
+++ b/src/test/java/org/sopt/pawkey/backendapi/domain/post/PostServiceTest.java
@@ -120,4 +120,18 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.updatePost(post, user, command))
                 .isInstanceOf(PostBusinessException.class);
     }
+    @Test
+    void 게시물_삭제_성공() {
+        // given
+        Long postId = 10L;
+
+        // when
+        postService.delete(postId);
+
+        // then
+        verify(postRepository).deleteById(postId);
+    }
+
+
+
 }

--- a/src/test/java/org/sopt/pawkey/backendapi/facade/post/PostDeleteFacadeTest.java
+++ b/src/test/java/org/sopt/pawkey/backendapi/facade/post/PostDeleteFacadeTest.java
@@ -1,0 +1,77 @@
+package org.sopt.pawkey.backendapi.facade.post;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.pawkey.backendapi.domain.image.application.service.command.ImageService;
+import org.sopt.pawkey.backendapi.domain.image.domain.model.ImageType;
+import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
+import org.sopt.pawkey.backendapi.domain.post.application.facade.command.PostDeleteFacade;
+import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostImageEntity;
+import org.sopt.pawkey.backendapi.domain.routes.application.service.RouteService;
+import org.sopt.pawkey.backendapi.domain.routes.infra.persistence.entity.RouteEntity;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostDeleteFacadeTest {
+
+	@Mock private UserService userService;
+	@Mock private PostService postService;
+	@Mock private RouteService routeService;
+	@Mock private ImageService imageService;
+
+	@InjectMocks
+	private PostDeleteFacade postDeleteFacade;
+
+	@Test
+	void 산책_게시물_삭제_유즈케이스_정상() {
+		// given
+		Long userId = 1L;
+		Long postId = 10L;
+		Long routeId = 20L;
+		Long walkImageId = 201L;
+		Long routeImageId = 100L;
+
+		UserEntity user = mock(UserEntity.class);
+		RouteEntity route = mock(RouteEntity.class);
+		PostEntity post = mock(PostEntity.class);
+
+		ImageEntity walkImage = mock(ImageEntity.class);
+		ImageEntity routeImage = mock(ImageEntity.class);
+
+		PostImageEntity postImageEntity = mock(PostImageEntity.class);
+
+		given(userService.findById(userId)).willReturn(user);
+		given(postService.findWithImagesForDelete(postId)).willReturn(post);
+
+		given(post.getPostId()).willReturn(postId);
+		given(post.getRoute()).willReturn(route);
+		given(route.getRouteId()).willReturn(routeId);
+		given(route.getTrackingImage()).willReturn(routeImage);
+		given(routeImage.getImageId()).willReturn(routeImageId);
+
+		given(postImageEntity.getImageType()).willReturn(ImageType.WALK_POST);
+		given(postImageEntity.getImage()).willReturn(walkImage);
+		given(walkImage.getImageId()).willReturn(walkImageId);
+		given(post.getPostImageEntityList()).willReturn(List.of(postImageEntity));
+
+		// when
+		postDeleteFacade.execute(userId, postId);
+
+		// then
+		verify(imageService).deleteImageById(walkImageId);
+		verify(imageService).deleteImageById(routeImageId);
+		verify(postService).delete(postId);
+		verify(routeService).delete(routeId);
+	}
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] 산책 게시물 삭제 API 구현

---

## ✨ 요약 설명
사용자가 등록한 산책 게시물을 삭제하는 API를 구현했습니다. 게시물 삭제 시 연결된 Route 및 ImageEntity(DB)도 함께 삭제됩니다. S3 파일 삭제는 추후 S3Client 빈 추가 후 별도 구현 예정입니다.

---

## 🧾 변경 사항
- 무엇을 추가/수정/삭제했나요?
- 어떤 파일 또는 모듈이 변경되었나요?

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] 테스트코드 검증
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- PostDeleteFacade에서 ImageEntity DB 삭제 후 Post/Route 순으로 삭제하는 순서에 대해 확인 부탁드립니다.
- S3 파일 삭제는 현재 TODO로 남겨뒀습니다. S3Client 빈 추가 후 별도 PR로 처리 예정입니다.
- findWithImagesForDelete 전용 EntityGraph를 분리한 이유는 기존 getByPostId가 좋아요/수정 등 다른 유즈케이스에서도 공유되어 불필요한 이미지 로딩을 피하기 위함입니다.

---


- Close #291 
- Fix #이슈번호