### PR TITLE
[fix] SpringDataPostRepository 쿼리 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
@@ -26,7 +26,12 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
 	})
 	Optional<PostEntity> getByPostId(Long postId);
 
-	@EntityGraph(attributePaths = {"postImageEntityList","postImageEntityList.image","route.trackingImage"})
+	@Query("SELECT DISTINCT p FROM PostEntity p " +
+		"LEFT JOIN FETCH p.postImageEntityList pil " +
+		"LEFT JOIN FETCH pil.image " +
+		"LEFT JOIN FETCH p.route r " +
+		"LEFT JOIN FETCH r.trackingImage " +
+		"WHERE p.postId = :postId")
 	Optional<PostEntity> findWithImagesForDelete(Long postId);
 
 


### PR DESCRIPTION
## 📌 PR 제목
[fix] SpringDataPostRepository 쿼리 오류 수정

---

## ✨ 요약 설명
findWithImagesForDelete 메서드에 @EntityGraph만 선언해 JPA가 메서드명 기반 쿼리로 파싱하려다 앱 구동 실패한 문제를 수정했습니다. @Query JPQL 방식으로 교체했습니다.
---

## 🧾 변경 사항
- SpringDataPostRepository.findWithImagesForDelete - @EntityGraph → @Query JPQL로 교체

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- 리뷰할 때 집중해서 봐주었으면 하는 부분
- 고민 중인 로직 또는 개선점 등

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #293 
- Fix #이슈번호