### PR TITLE
[feat] 리뷰 등록 선택 조건 검증 추가 및 리뷰 메타데이터 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/controller/ReviewController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/controller/ReviewController.java
@@ -2,16 +2,18 @@ package org.sopt.pawkey.backendapi.domain.review.api.controller;
 
 import static org.sopt.pawkey.backendapi.global.constants.AppConstants.*;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import org.sopt.pawkey.backendapi.domain.auth.annotation.UserId;
 import org.sopt.pawkey.backendapi.domain.review.api.dto.request.ReviewCreateRequestDto;
+import org.sopt.pawkey.backendapi.domain.review.api.dto.response.ReviewHeaderResponseDto;
 import org.sopt.pawkey.backendapi.domain.review.application.dto.command.ReviewRegisterCommand;
+import org.sopt.pawkey.backendapi.domain.review.application.dto.result.ReviewHeaderResult;
+import org.sopt.pawkey.backendapi.domain.review.application.facade.GetReviewHeaderFacade;
 import org.sopt.pawkey.backendapi.domain.review.application.facade.ReviewRegisterFacade;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -26,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class ReviewController {
 
 	private final ReviewRegisterFacade reviewRegisterFacade;
+	private final GetReviewHeaderFacade getReviewHeaderFacade;
 
 	@Operation(summary = "리뷰 카테고리 등록", description = "공유된 루트로 산책 완료 후, 리뷰 카테고리를 등록합니다.", tags = {"Reviews"})
 	@ApiResponses({
@@ -42,6 +45,23 @@ public class ReviewController {
 		reviewRegisterFacade.execute(userId, command);
 
 		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+
+
+
+	@Operation(summary = "리뷰 메타데이터 조회", description = "리뷰 작성 화면 상단에 표시할 게시물 제목 및 후기 작성자 프로필을 조회합니다.", tags = {"Reviews"})
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 게시물", content = @Content(mediaType = "application/json")),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
+	})
+	@GetMapping("/{postId}/review-header")
+	public ResponseEntity<ApiResponse<ReviewHeaderResponseDto>> getReviewHeader(
+			@Parameter(hidden = true) @UserId Long userId,
+			@PathVariable Long postId
+	) {
+		ReviewHeaderResult result = getReviewHeaderFacade.execute(postId, userId);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(ReviewHeaderResponseDto.from(result)));
 	}
 
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/response/ReviewHeaderResponseDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/api/dto/response/ReviewHeaderResponseDto.java
@@ -1,0 +1,24 @@
+package org.sopt.pawkey.backendapi.domain.review.api.dto.response;
+
+
+import org.sopt.pawkey.backendapi.domain.review.application.dto.result.ReviewHeaderResult;
+
+public record ReviewHeaderResponseDto(
+        String postTitle,
+        ReviewerProfile reviewerProfile
+) {
+    public record ReviewerProfile(
+            String profileName,
+            String profileImageUrl
+    ) {}
+
+    public static ReviewHeaderResponseDto from(ReviewHeaderResult result) {
+        return new ReviewHeaderResponseDto(
+                result.postTitle(),
+                new ReviewerProfile(
+                        result.profileName(),
+                        result.profileImageUrl()
+                )
+        );
+    }
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/dto/result/ReviewHeaderResult.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/dto/result/ReviewHeaderResult.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.review.application.dto.result;
+
+public record ReviewHeaderResult(
+        String postTitle,
+        String profileName,
+        String profileImageUrl
+) {}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/GetReviewHeaderFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/application/facade/GetReviewHeaderFacade.java
@@ -1,0 +1,37 @@
+package org.sopt.pawkey.backendapi.domain.review.application.facade;
+import org.sopt.pawkey.backendapi.domain.image.application.service.PresignedImageService;
+import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
+import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.review.application.dto.result.ReviewHeaderResult;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetReviewHeaderFacade {
+
+    private final PostService postService;
+    private final UserService userService;
+    private final PresignedImageService presignedImageService;
+
+    public ReviewHeaderResult execute(Long postId, Long userId) {
+        PostEntity post = postService.findById(postId);
+        UserEntity user = userService.findById(userId);
+        PetEntity pet = user.getPetOrThrow();
+
+        String profileImageUrl = pet.getProfileImage() != null
+                ? presignedImageService.createPresignedGetUrl(pet.getProfileImage().getImageUrl())
+                : null;
+
+        return new ReviewHeaderResult(
+                post.getTitle(),
+                pet.getName(),
+                profileImageUrl
+        );
+    }
+}

--- a/src/test/java/org/sopt/pawkey/backendapi/facade/review/GetReviewHeaderFacadeTest.java
+++ b/src/test/java/org/sopt/pawkey/backendapi/facade/review/GetReviewHeaderFacadeTest.java
@@ -1,0 +1,87 @@
+package org.sopt.pawkey.backendapi.facade.review;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.pawkey.backendapi.domain.image.application.service.PresignedImageService;
+import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
+import org.sopt.pawkey.backendapi.domain.pet.infra.persistence.entity.PetEntity;
+import org.sopt.pawkey.backendapi.domain.post.application.service.PostService;
+import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.review.application.dto.result.ReviewHeaderResult;
+import org.sopt.pawkey.backendapi.domain.review.application.facade.GetReviewHeaderFacade;
+import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class GetReviewHeaderFacadeTest {
+
+    @Mock private PostService postService;
+    @Mock private UserService userService;
+    @Mock private PresignedImageService presignedImageService;
+
+    @InjectMocks
+    private GetReviewHeaderFacade getReviewHeaderFacade;
+
+    @Test
+    void 리뷰_헤더_조회_성공() {
+        // given
+        Long userId = 1L;
+        Long postId = 10L;
+
+        PostEntity post = mock(PostEntity.class);
+        UserEntity user = mock(UserEntity.class);
+        PetEntity pet = mock(PetEntity.class);
+        ImageEntity profileImage = mock(ImageEntity.class);
+
+        given(postService.findById(postId)).willReturn(post);
+        given(userService.findById(userId)).willReturn(user);
+        given(user.getPetOrThrow()).willReturn(pet);
+        given(post.getTitle()).willReturn("단지와의 룰루랄라");
+        given(pet.getName()).willReturn("손민수");
+        given(pet.getProfileImage()).willReturn(profileImage);
+        given(profileImage.getImageUrl()).willReturn("https://s3.../profile/uuid.jpg");
+        given(presignedImageService.createPresignedGetUrl("https://s3.../profile/uuid.jpg"))
+                .willReturn("https://presigned.../profile/uuid.jpg");
+
+        // when
+        ReviewHeaderResult result = getReviewHeaderFacade.execute(postId, userId);
+
+        // then
+        assertThat(result.postTitle()).isEqualTo("단지와의 룰루랄라");
+        assertThat(result.profileName()).isEqualTo("손민수");
+        assertThat(result.profileImageUrl()).isEqualTo("https://presigned.../profile/uuid.jpg");
+    }
+
+    @Test
+    void 리뷰_헤더_조회_성공_프로필이미지_없음() {
+        // given
+        Long userId = 1L;
+        Long postId = 10L;
+
+        PostEntity post = mock(PostEntity.class);
+        UserEntity user = mock(UserEntity.class);
+        PetEntity pet = mock(PetEntity.class);
+
+        given(postService.findById(postId)).willReturn(post);
+        given(userService.findById(userId)).willReturn(user);
+        given(user.getPetOrThrow()).willReturn(pet);
+        given(post.getTitle()).willReturn("단지와의 룰루랄라");
+        given(pet.getName()).willReturn("손민수");
+        given(pet.getProfileImage()).willReturn(null);
+
+        // when
+        ReviewHeaderResult result = getReviewHeaderFacade.execute(postId, userId);
+
+        // then
+        assertThat(result.postTitle()).isEqualTo("단지와의 룰루랄라");
+        assertThat(result.profileName()).isEqualTo("손민수");
+        assertThat(result.profileImageUrl()).isNull();
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] 리뷰 등록 선택 조건 검증 추가 및 리뷰 메타데이터 조회 API 구현
---

## ✨ 요약 설명
기존 리뷰 등록 API에 카테고리 선택 조건 검증 로직을 추가하고, 리뷰 작성 화면 상단에 표시할 메타데이터(게시물 제목, 후기 작성자 펫 프로필) 조회 API를 새로 구현했습니다.

---

## 🧾 변경 사항
- ReviewRegisterFacade - 카테고리 선택 조건 검증 로직 추가 (SINGLE/MULTIPLE, 필수 카테고리 누락 검증)
- ReviewService.saveReview - 검증된 selectedOptions 파라미터 받도록 리팩토링, N+1 개선
- GetReviewHeaderFacade - 신규 생성 (게시물 제목 + 펫 프로필 조회)
- ReviewHeaderResult - 신규 생성
- ReviewHeaderResponseDto - 신규 생성
- ReviewController - GET /{postId}/review-header 엔드포인트 추가
- ReviewRegisterFacadeTest, ReviewServiceTest, GetReviewHeaderFacadeTest - 테스트 코드 작성
---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함
- [x] 테스트코드 검증

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- ReviewRegisterFacade에 PostRegisterFacade와 동일한 카테고리 검증 로직을 추가했는데, 중복 제거 관점에서 공통 컴포넌트로 분리할지 논의 부탁드립니다
- ReviewCategoryOptionTop3 갱신 로직은 현재 주석 처리 상태입니다. 추후 별도 PR로 구현 예정입니다.
- GetReviewHeaderFacade는 로직이 단순해 별도 Service 없이 Facade에서 직접 처리했습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #296 
- Fix #이슈번호