### PR TITLE
[fix] 게시물 삭제 시 소유자 검증 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/post/infra/persistence/repository/SpringDataPostRepository.java
@@ -27,6 +27,7 @@ public interface SpringDataPostRepository extends JpaRepository<PostEntity, Long
 	Optional<PostEntity> getByPostId(Long postId);
 
 	@Query("SELECT DISTINCT p FROM PostEntity p " +
+		"LEFT JOIN FETCH p.user " +
 		"LEFT JOIN FETCH p.postImageEntityList pil " +
 		"LEFT JOIN FETCH pil.image " +
 		"LEFT JOIN FETCH p.route r " +


### PR DESCRIPTION
## 📌 PR 제목
[fix] 게시물 삭제 시 소유자 검증 오류 수정

---

## ✨ 요약 설명
게시물 삭제 시 소유자 검증에서 user가 프록시 객체로 로딩되어 equals() 비교 시 클래스 타입 불일치로 항상 실패하던 문제를 수정했습니다. findWithImagesForDelete 쿼리에 user fetch join을 추가했습니다.

---

## 🧾 변경 사항
- SpringDataPostRepository.findWithImagesForDelete - LEFT JOIN FETCH p.user 추가

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- Hibernate 프록시 객체와 실제 엔티티 간 equals() 비교 시 클래스 타입이 달라 항상 false를 반환하는 이슈입니다. 소유자 검증이 필요한 다른 API에서도 동일한 패턴이 있는지 확인 부탁드립니다.

---
