### PR TITLE
[bug] Post 삭제 시 연관 Review FK 제약 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/routes/infra/persistence/entity/RouteEntity.java
@@ -9,6 +9,7 @@ import org.locationtech.jts.geom.LineString;
 import org.sopt.pawkey.backendapi.domain.image.infra.persistence.entity.ImageEntity;
 import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewCategoryOptionTop3Entity;
+import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
 import org.sopt.pawkey.backendapi.domain.routes.exception.RouteBusinessException;
 import org.sopt.pawkey.backendapi.domain.routes.exception.RouteErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
@@ -64,6 +65,9 @@ public class RouteEntity extends BaseEntity {
 
 	@Column(name = "step_count", nullable = false)
 	private Integer stepCount;
+
+	@OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	private List<ReviewEntity> reviews = new ArrayList<>();
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "region_id", nullable = false)


### PR DESCRIPTION
## 📌 PR 제목
ex) [feat] 회원가입 API 구현  
ex) [bug] JWT 검증 오류 수정  
ex) [refactor] 응답 포맷 통일

---

## ✨ 요약 설명
Post 삭제 시 Route가 함께 삭제되는데, Route를 참조하는 Review가 남아있어 FK 제약 위반으로 500 에러가 발생하던 문제를 수정했습니다.

---

## 🧾 변경 사항
- `RouteEntity`에 `reviews` 양방향 관계 추가 (`CascadeType.ALL`, `orphanRemoval = true`)
- Post 삭제 시 Route → Review 순으로 cascade 삭제되도록 처리

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [x] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- Route 삭제 시 Review도 함께 삭제되는 것이 올바른 비즈니스 로직인지 확인 부탁드립니다.
- Post는 Route에 대한 게시글이므로 Post → Route → Review 순의 생명주기가 맞다고 판단했습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #이슈번호
- Fix #이슈번호