### PR TITLE
[fix] 회원탈퇴 시 review 삭제 누락으로 인한 FK 제약 위반 오류 수정

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewRepository.java
@@ -9,4 +9,6 @@ public interface ReviewRepository {
 	void save(ReviewEntity review);
 
 	List<ReviewEntity> findAllByUserId(Long userId);
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/domain/repository/ReviewSelectedCategoryOptionRepository.java
@@ -9,4 +9,6 @@ public interface ReviewSelectedCategoryOptionRepository {
 	void saveAll(List<ReviewSelectedCategoryOptionEntity> selectedCategoryOptionEntityList);
 
 	List<Object[]> countCategoryOptionSelectionsByRoute(Long routeId);
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewRepositoryImpl.java
@@ -36,4 +36,9 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 			.orderBy(reviewEntity.reviewId.desc())
 			.fetch();
 	}
+
+	@Override
+	public void deleteByUserId(Long userId) {
+		jpaRepository.deleteByUserId(userId);
+	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/ReviewSelectedCategoryOptionRepositoryImpl.java
@@ -24,4 +24,9 @@ public class ReviewSelectedCategoryOptionRepositoryImpl implements ReviewSelecte
 		return jpaRepository.countCategoryOptionSelectionsByRoute(routeId);
 	}
 
+	@Override
+	public void deleteByUserId(Long userId) {
+		jpaRepository.deleteByUserId(userId);
+	}
+
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewRepository.java
@@ -1,7 +1,13 @@
 package org.sopt.pawkey.backendapi.domain.review.infra.persistence;
 
+import feign.Param;
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SpringDataReviewRepository extends JpaRepository<ReviewEntity, Long> {
+    @Modifying
+    @Query("DELETE FROM ReviewEntity r WHERE r.user.userId = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/review/infra/persistence/SpringDataReviewSelectedCategoryOptionRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.sopt.pawkey.backendapi.domain.review.infra.persistence.entity.ReviewSelectedCategoryOptionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,9 @@ public interface SpringDataReviewSelectedCategoryOptionRepository
 			ORDER BY COUNT(r) DESC
 		""")
 	List<Object[]> countCategoryOptionSelectionsByRoute(@Param("routeId") Long routeId);
+
+
+	@Modifying
+	@Query("DELETE FROM ReviewSelectedCategoryOptionEntity r WHERE r.review.user.userId = :userId")
+	void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserDeletionService.java
@@ -6,6 +6,8 @@ import org.sopt.pawkey.backendapi.domain.dbti.domain.repository.DbtiResultReposi
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostRepository;
 import org.sopt.pawkey.backendapi.domain.post.domain.repository.PostSelectedCategoryOptionRepository;
 import org.sopt.pawkey.backendapi.domain.post.infra.persistence.entity.PostEntity;
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewRepository;
+import org.sopt.pawkey.backendapi.domain.review.domain.repository.ReviewSelectedCategoryOptionRepository;
 import org.sopt.pawkey.backendapi.domain.routes.domain.repository.RouteRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.SocialAccountRepository;
 import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
@@ -25,6 +27,9 @@ public class UserDeletionService {
 
 	private final DbtiResultRepository dbtiResultRepository;
 	private final PostSelectedCategoryOptionRepository postSelectedCategoryOptionRepository;
+
+	private final ReviewSelectedCategoryOptionRepository reviewSelectedCategoryOptionRepository;
+	private final ReviewRepository reviewRepository;
 
 	private final PostRepository postRepository;
 	private final RouteRepository routeRepository;
@@ -51,6 +56,13 @@ public class UserDeletionService {
 		postRepository.deleteByRouteUserId(userId);
 		postRepository.deleteByUserId(userId);
 		entityManager.flush();
+
+		reviewSelectedCategoryOptionRepository.deleteByUserId(userId);
+		entityManager.flush();
+
+		reviewRepository.deleteByUserId(userId);
+		entityManager.flush();
+
 
 		// 5. routes
 		routeRepository.deleteByUserId(userId);


### PR DESCRIPTION
## 📌 PR 제목
[fix] 회원탈퇴 시 review 삭제 누락으로 인한 FK 제약 위반 오류 수정

---

## ✨ 요약 설명
회원탈퇴 시 routes 삭제 전 reviews 관련 테이블 삭제가 누락되어 FK 제약 위반이 발생하던 문제를 수정했습니다.

---

## 🧾 변경 사항

- ReviewSelectedCategoryOptionRepository - deleteByUserId() 추가
- SpringDataReviewSelectedCategoryOptionRepository - bulk delete 쿼리 추가
- ReviewRepository - deleteByUserId() 추가
- SpringDataReviewRepository - bulk delete 쿼리 추가
- UserDeletionService - routes 삭제 전 review 관련 테이블 삭제 순서 추가

---

## 📂 PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- JPQL bulk delete는 JPA cascade를 무시하고 DB에 직접 쿼리를 날리기 때문에, ReviewEntity cascade 설정과 무관하게 review_selected_category_option을 먼저 별도로 삭제해야 합니다.
- 회원탈퇴 삭제 순서 전체를 한번 더 검토 부탁드립니다!!

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #300 
- Fix #이슈번호