### PR TITLE
[FEAT] 소셜 로그인 응답에 userId, petId 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/auth/api/dto/response/SocialLoginResponseDTO.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/auth/api/dto/response/SocialLoginResponseDTO.java
@@ -6,13 +6,17 @@ import lombok.Builder;
 public record SocialLoginResponseDTO(
 	String accessToken,
 	String refreshToken,
-	boolean isNewUser
+	boolean isNewUser,
+	Long userId,
+	Long petId
 ) {
-	public static SocialLoginResponseDTO of(TokenResponseDTO tokenResponse, boolean isNewUser){
+	public static SocialLoginResponseDTO of(TokenResponseDTO tokenResponse, boolean isNewUser,  Long userId, Long petId){
 		return SocialLoginResponseDTO.builder()
 			.accessToken(tokenResponse.accessToken())
 			.refreshToken(tokenResponse.refreshToken())
 			.isNewUser(isNewUser)
+			.userId(userId)
+			.petId(petId)
 			.build();
 	}
 }

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/facade/UserLoginFacade.java
@@ -14,6 +14,7 @@ import org.sopt.pawkey.backendapi.domain.auth.exception.AuthBusinessException;
 import org.sopt.pawkey.backendapi.domain.auth.exception.AuthErrorCode;
 import org.sopt.pawkey.backendapi.domain.user.api.dto.result.UserCreationResult;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,7 +40,11 @@ public class UserLoginFacade {
 
 		UserCreationResult creationResult = userService.findOrCreateUserBySocialId(Provider.GOOGLE, platformUserId, primaryEmail);
 		TokenResponseDTO tokens = tokenService.issueTokens(creationResult.userId(), deviceId);
-		return SocialLoginResponseDTO.of(tokens, creationResult.isNewUser());
+
+		UserEntity user = userService.findById(creationResult.userId());
+		Long petId = user.getPet() != null ? user.getPet().getPetId() : null;
+
+		return SocialLoginResponseDTO.of(tokens, creationResult.isNewUser(), creationResult.userId(), petId);
 	}
 
 	public SocialLoginResponseDTO kakaoLogin(String accessToken, String deviceId) {
@@ -52,7 +57,10 @@ public class UserLoginFacade {
 		);
 
 		TokenResponseDTO tokens = tokenService.issueTokens(creationResult.userId(), deviceId);
-		return SocialLoginResponseDTO.of(tokens, creationResult.isNewUser());
+		UserEntity user = userService.findById(creationResult.userId());
+		Long petId = user.getPet() != null ? user.getPet().getPetId() : null;
+
+		return SocialLoginResponseDTO.of(tokens, creationResult.isNewUser(), creationResult.userId(), petId);
 
 	}
 
@@ -85,11 +93,13 @@ public class UserLoginFacade {
 			appleRefreshTokenService.saveOrUpdate(result.userId(), refreshToken);
 		}
 
-		//JWT 발급
-		return SocialLoginResponseDTO.of(
-			tokenService.issueTokens(result.userId(), deviceId),
-			result.isNewUser()
-		);
+
+
+		TokenResponseDTO tokens = tokenService.issueTokens(result.userId(), deviceId);
+		UserEntity user = userService.findById(result.userId());
+		Long petId = user.getPet() != null ? user.getPet().getPetId() : null;
+
+		return SocialLoginResponseDTO.of(tokens, result.isNewUser(), result.userId(), petId);
 	}
 
 }


### PR DESCRIPTION
## 📌 PR 제목
소셜 로그인 응답에 userId, petId 추가

---

## ✨ 요약 설명
소셜 로그인 응답에 userId와 petId를 추가했습니다. pet이 없는 신규 유저의 경우 petId는 null로 반환됩니다.

---

## 🧾 변경 사항

- SocialLoginResponseDTO - userId, petId 필드 추가 및 of() 메서드 파라미터 수정
- UserLoginFacade - google, kakao, apple 로그인 시 user 조회 후 userId, petId 응답에 포함

---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [ ] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [ ] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [ ] Swagger/문서화는 최신 상태인가?
- [ ] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
-로그인 시 userService.findById()를 한 번 더 호출하는 구조라 쿼리가 추가됩니다. 성능 개선이 필요하다면 - findOrCreateUserBySocialId에서 pet 정보까지 함께 반환하는 방식으로 리팩토링할 수 있습니다.

---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #302 
- Fix #이슈번호