### PR TITLE
[feat] 탈퇴 사유 제출 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+.claude/
 
 /src/main/resources/application.yml
 /src/main/resources/application-*.yml

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/controller/UserController.java
@@ -20,7 +20,9 @@ import org.sopt.pawkey.backendapi.domain.user.application.facade.command.UpdateU
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserLikedPostQueryFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserQueryFacade;
 import org.sopt.pawkey.backendapi.domain.user.application.facade.query.UserWrittenPostQueryFacade;
+import org.sopt.pawkey.backendapi.domain.user.api.dto.request.WithdrawReasonRequestDto;
 import org.sopt.pawkey.backendapi.domain.user.application.service.UserService;
+import org.sopt.pawkey.backendapi.domain.user.application.service.WithdrawReasonService;
 import org.sopt.pawkey.backendapi.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -69,6 +71,7 @@ public class UserController {
 	}
 
 	private final UserService userService;
+	private final WithdrawReasonService withdrawReasonService;
 
 	@Operation(summary = "닉네임 중복 검사", description = "파라미터로 받은 닉네임의 중복 여부를 확인합니다.", tags = {"Users"})
 	@ApiResponses({
@@ -158,6 +161,21 @@ public class UserController {
 
 		return ResponseEntity.ok(
 			ApiResponse.success());
+	}
+
+	@Operation(summary = "탈퇴 사유 제출", description = "회원탈퇴 전 탈퇴 사유를 제출합니다.", tags = {"Users"})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 사유 제출 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "reasonCode 누락", content = @Content(mediaType = "application/json")),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json"))
+	})
+	@PostMapping("/withdraw-reason")
+	public ResponseEntity<ApiResponse<Void>> submitWithdrawReason(
+		@Parameter(hidden = true) @UserId Long userId,
+		@RequestBody @Valid WithdrawReasonRequestDto requestDto
+	) {
+		withdrawReasonService.saveWithdrawReason(userId, requestDto);
+		return ResponseEntity.ok(ApiResponse.success());
 	}
 
 	@GetMapping("/me/reviews")

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/WithdrawReasonRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/WithdrawReasonRequestDto.java
@@ -1,0 +1,11 @@
+package org.sopt.pawkey.backendapi.domain.user.api.dto.request;
+
+import org.sopt.pawkey.backendapi.domain.user.domain.WithdrawReasonCode;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WithdrawReasonRequestDto(
+	@NotNull(message = "탈퇴 사유 코드는 필수값입니다.")
+	WithdrawReasonCode reasonCode
+) {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/WithdrawReasonService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/WithdrawReasonService.java
@@ -1,0 +1,25 @@
+package org.sopt.pawkey.backendapi.domain.user.application.service;
+
+import org.sopt.pawkey.backendapi.domain.user.api.dto.request.WithdrawReasonRequestDto;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.WithdrawReasonRepository;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.WithdrawReasonEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawReasonService {
+
+	private final WithdrawReasonRepository withdrawReasonRepository;
+
+	@Transactional
+	public void saveWithdrawReason(Long userId, WithdrawReasonRequestDto requestDto) {
+		WithdrawReasonEntity entity = WithdrawReasonEntity.builder()
+			.userId(userId)
+			.reasonCode(requestDto.reasonCode())
+			.build();
+		withdrawReasonRepository.save(entity);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/domain/WithdrawReasonCode.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/domain/WithdrawReasonCode.java
@@ -1,0 +1,10 @@
+package org.sopt.pawkey.backendapi.domain.user.domain;
+
+public enum WithdrawReasonCode {
+	LOW_ACTIVITY,
+	LOW_USAGE,
+	USABILITY_COMPLEX,
+	FEATURE_LACK,
+	USING_OTHER_SERVICE,
+	ETC
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/domain/repository/WithdrawReasonRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/domain/repository/WithdrawReasonRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.user.domain.repository;
+
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.WithdrawReasonEntity;
+
+public interface WithdrawReasonRepository {
+	WithdrawReasonEntity save(WithdrawReasonEntity entity);
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SpringDataWithdrawReasonRepository.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/SpringDataWithdrawReasonRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.WithdrawReasonEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataWithdrawReasonRepository extends JpaRepository<WithdrawReasonEntity, Long> {
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/WithdrawReasonRepositoryImpl.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/WithdrawReasonRepositoryImpl.java
@@ -1,0 +1,19 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence;
+
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.WithdrawReasonRepository;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.WithdrawReasonEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class WithdrawReasonRepositoryImpl implements WithdrawReasonRepository {
+
+	private final SpringDataWithdrawReasonRepository springDataWithdrawReasonRepository;
+
+	@Override
+	public WithdrawReasonEntity save(WithdrawReasonEntity entity) {
+		return springDataWithdrawReasonRepository.save(entity);
+	}
+}

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/WithdrawReasonEntity.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/infra/persistence/entity/WithdrawReasonEntity.java
@@ -1,0 +1,38 @@
+package org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity;
+
+import org.sopt.pawkey.backendapi.domain.user.domain.WithdrawReasonCode;
+import org.sopt.pawkey.backendapi.global.infra.persistence.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "withdraw_reasons")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class WithdrawReasonEntity extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "reason_code", nullable = false, length = 30)
+	private WithdrawReasonCode reasonCode;
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat] 탈퇴 사유 제출 API 구현

---

## ✨ 요약 설명
  회원탈퇴 전 탈퇴 사유를 수집하는 API를 구현했습니다. 분석용 데이터 저장을 목적으로 합니다.


---

## 🧾 변경 사항
- POST /api/v1/users/withdraw-reason 엔드포인트 추가
- WithdrawReasonCode Enum, Entity, Repository, Service 추가



---

## 📂 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
 - userId를 FK 대신 Long으로 저장했습니다. 유저 하드 딜리트 시 분석 데이터 보존을 위해서입니다.



---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #306 
- Fix #306 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 탈퇴 시 사유를 제출할 수 있는 API 엔드포인트 추가

* **Chores**
  * 내부 설정 파일 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->