### PR TITLE
[refactor] UserService 닉네임 중복 검증 로직 추출 및 단위 테스트 추가

### DIFF
--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/UpdateUserInfoRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/UpdateUserInfoRequestDto.java
@@ -6,8 +6,10 @@ import org.sopt.pawkey.backendapi.domain.user.application.dto.request.UpdateUser
 import org.sopt.pawkey.backendapi.global.enums.Gender;
 
 import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
 
 public record UpdateUserInfoRequestDto(
+	@Size(min = 1, message = "닉네임은 1자 이상이어야 합니다.")
 	String name,
 
 	@PastOrPresent(message = "생년월일은 현재 또는 과거 날짜여야 합니다")

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/UserOnboardingRequestDto.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/api/dto/request/UserOnboardingRequestDto.java
@@ -11,9 +11,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record UserOnboardingRequestDto(
-	@NotNull(message = "이름은 필수값입니다.") String name,
+	@NotNull(message = "이름은 필수값입니다.")
+	@Size(min = 1, message = "닉네임은 1자 이상이어야 합니다.")
+	String name,
 
 	@NotNull(message = "생년월일은 필수값입니다.")
 	@JsonFormat(pattern = "yyyy-MM-dd") LocalDate birth,

--- a/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
+++ b/src/main/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserService.java
@@ -47,9 +47,7 @@ public class UserService {
 	@Transactional
 	public UserEntity completeOnboarding(Long userId, OnboardingInfoCommand command, RegionEntity region) {
 
-		if (userRepository.existsByName(command.name())) {
-			throw new UserBusinessException(UserErrorCode.USER_DUPLICATE_NICKNAME);
-		}
+		validateNicknameDuplicate(command.name());
 
 		UserEntity user = userRepository.findById(userId)
 			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
@@ -67,6 +65,12 @@ public class UserService {
 
 	public void updateUserRegion(UserEntity user, RegionEntity region) {
 		user.updateRegion(region);
+	}
+
+	private void validateNicknameDuplicate(String name) {
+		if (userRepository.existsByName(name)) {
+			throw new UserBusinessException(UserErrorCode.USER_DUPLICATE_NICKNAME);
+		}
 	}
 
 	@Transactional
@@ -117,9 +121,7 @@ public class UserService {
 			.orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
 
 		if (command.name() != null && !command.name().equals(user.getName())) {
-			if (userRepository.existsByName(command.name())) {
-				throw new UserBusinessException(UserErrorCode.USER_DUPLICATE_NICKNAME);
-			}
+			validateNicknameDuplicate(command.name());
 		}
 
 		try {

--- a/src/test/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserServiceTest.java
+++ b/src/test/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserServiceTest.java
@@ -1,0 +1,104 @@
+package org.sopt.pawkey.backendapi.domain.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.pawkey.backendapi.domain.region.infra.persistence.entity.RegionEntity;
+import org.sopt.pawkey.backendapi.domain.user.application.dto.request.OnboardingInfoCommand;
+import org.sopt.pawkey.backendapi.domain.user.application.dto.request.UpdateUserInfoCommand;
+import org.sopt.pawkey.backendapi.domain.user.domain.repository.UserRepository;
+import org.sopt.pawkey.backendapi.domain.user.exception.UserBusinessException;
+import org.sopt.pawkey.backendapi.domain.user.infra.persistence.entity.UserEntity;
+import org.sopt.pawkey.backendapi.global.enums.Gender;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	private static final Long USER_ID = 1L;
+
+	@Mock private UserRepository userRepository;
+
+	@InjectMocks
+	private UserService userService;
+
+	@Test
+	void 온보딩_중복닉네임이면_예외() {
+		// given
+		OnboardingInfoCommand command = new OnboardingInfoCommand("중복닉네임", LocalDate.of(1999, 1, 1), Gender.F, 1L);
+		given(userRepository.existsByName("중복닉네임")).willReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> userService.completeOnboarding(USER_ID, command, mock(RegionEntity.class)))
+			.isInstanceOf(UserBusinessException.class);
+	}
+
+	@Test
+	void 닉네임_변경시_중복이면_예외() {
+		// given
+		UserEntity user = userWithName("기존닉네임");
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+		given(userRepository.existsByName("중복닉네임")).willReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> userService.updateUserInfo(USER_ID, new UpdateUserInfoCommand("중복닉네임", null, null)))
+			.isInstanceOf(UserBusinessException.class);
+	}
+
+	@Test
+	void 현재_닉네임과_같으면_중복검사_생략() {
+		// given
+		UserEntity user = userWithName("기존닉네임");
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+		// when
+		userService.updateUserInfo(USER_ID, new UpdateUserInfoCommand("기존닉네임", null, null));
+
+		// then
+		verify(userRepository, never()).existsByName("기존닉네임");
+	}
+
+	@Test
+	void 닉네임이_null이면_변경_의도_없는것으로_간주한다() {
+		// given
+		UserEntity user = mock(UserEntity.class);
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+		// when
+		userService.updateUserInfo(USER_ID, new UpdateUserInfoCommand(null, null, null));
+
+		// then
+		verify(userRepository, never()).existsByName(any());
+	}
+
+	@Test
+	void 유저정보_수정_정상_저장() {
+		// given
+		UserEntity user = userWithName("기존닉네임");
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+		given(userRepository.existsByName("새닉네임")).willReturn(false);
+
+		// when
+		userService.updateUserInfo(USER_ID, new UpdateUserInfoCommand("새닉네임", null, null));
+
+		// then
+		verify(userRepository).saveAndFlush(user);
+	}
+
+	private UserEntity userWithName(String name) {
+		UserEntity user = mock(UserEntity.class);
+		given(user.getName()).willReturn(name);
+		return user;
+	}
+}

--- a/src/test/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserServiceTest.java
+++ b/src/test/java/org/sopt/pawkey/backendapi/domain/user/application/service/UserServiceTest.java
@@ -96,6 +96,42 @@ class UserServiceTest {
 		verify(userRepository).saveAndFlush(user);
 	}
 
+	@Test
+	void 닉네임_중복검사_본인닉네임은_통과() {
+		// given
+		UserEntity user = userWithName("내닉네임");
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+		// when
+		userService.isNicknameDuplicated(USER_ID, "내닉네임");
+
+		// then
+		verify(userRepository, never()).existsByName(any());
+	}
+
+	@Test
+	void 닉네임_중복검사_이미_사용중이면_예외() {
+		// given
+		UserEntity user = userWithName("내닉네임");
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+		given(userRepository.existsByName("타인닉네임")).willReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> userService.isNicknameDuplicated(USER_ID, "타인닉네임"))
+			.isInstanceOf(UserBusinessException.class);
+	}
+
+	@Test
+	void 닉네임_중복검사_사용가능하면_통과() {
+		// given
+		UserEntity user = userWithName("내닉네임");
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+		given(userRepository.existsByName("새닉네임")).willReturn(false);
+
+		// when & then (예외 없이 정상 반환)
+		userService.isNicknameDuplicated(USER_ID, "새닉네임");
+	}
+
 	private UserEntity userWithName(String name) {
 		UserEntity user = mock(UserEntity.class);
 		given(user.getName()).willReturn(name);


### PR DESCRIPTION
## 📌 PR 제목
[refactor] UserService 닉네임 중복 검증 로직 추출 및 단위 테스트 추가

---

## ✨ 요약 설명
- completeOnboarding과 updateUserInfo에 흩어져 있던 닉네임 중복 검증 로직을 validateNicknameDuplicate()로 추출했습니다. 
- 리팩토링 과정에서 빈 문자열 닉네임이 통과되는 gap을 발견해 DTO 레이어에서 차단했고, 단위 테스트를 작성했습니다.


---

## 🧾 변경 사항
- UserService — 중복 닉네임 검증 로직을 validateNicknameDuplicate() private 메서드로 추출
- UpdateUserInfoRequestDto, UserOnboardingRequestDto — name 필드에 @Size(min = 1) 추가 (빈 문자열 차단)
- UserServiceTest — validateNicknameDuplicate 동작 및 isNicknameDuplicated 단위 테스트 8개 추가 

---

## 📂 PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (직접 작성: )

---

## 🧪 테스트
- [x] Postman으로 API 호출 확인
- [ ] 로컬 실행 결과 화면 캡처 포함

---

## ✅ 체크리스트
- [x] [깃 & 코드 컨벤션](https://shadow-impatiens-f13.notion.site/Git-Code-215564d8d2a780f186e3f562dc687a2f)을 지켰는가?
- [x] Swagger/문서화는 최신 상태인가?
- [x] 기능 변경 시 영향 받는 모듈을 확인했는가?

---

## 💬 리뷰어에게 전달할 말
- validateNicknameDuplicate()가 두 메서드에서 공유되므로 해당 메서드 위주로 봐주시면 됩니다.
- 빈 문자열 차단을 서비스가 아닌 DTO 레이어에서 처리했습니다. 레이어 책임 분리 관점에서 의도한 설계이니 참고 부탁드립니다.


---

## 🔗 관련 이슈
> 아래 `이슈번호` 에 번호를 적으면 풀리퀘스트 [머지 완료 시 자동으로 해당 이슈가 닫힙니다](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue). 

- Close #308 
- Fix #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 닉네임 입력값 검증 강화: 닉네임은 최소 1자 이상이어야 합니다.

* **개선 사항**
  * 닉네임 중복 검증 로직 최적화로 안정성 향상

* **테스트**
  * 사용자 온보딩 및 정보 업데이트 시 닉네임 중복 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->